### PR TITLE
Set SubjectAttribute usage to Inherit = true

### DIFF
--- a/Source/Machine.Specifications/SubjectAttribute.cs
+++ b/Source/Machine.Specifications/SubjectAttribute.cs
@@ -5,7 +5,7 @@ using Machine.Specifications.Utility;
 
 namespace Machine.Specifications
 {
-  [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+  [AttributeUsage(AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
   [MeansImplicitUse(ImplicitUseTargetFlags.WithMembers)]
   public class SubjectAttribute : Attribute
   {


### PR DESCRIPTION
This should address Issue 10.

http://github.com/machine/machine.specifications/issues#issue/10

I think this allows some nice code simplification, by allowing the Subject and Tags to be defined in a specification base class. A derived class can still override the definition by defining the attribute itself if needed.
