### PR TITLE
Quick patch to prevent R# from marking Behaviors as unused

### DIFF
--- a/Source/Machine.Specifications/BehaviorsAttribute.cs
+++ b/Source/Machine.Specifications/BehaviorsAttribute.cs
@@ -1,8 +1,10 @@
 using System;
+using Machine.Specifications.Annotations;
 
 namespace Machine.Specifications
 {
   [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+  [MeansImplicitUse(ImplicitUseTargetFlags.WithMembers)]
   public class BehaviorsAttribute : Attribute
   {
   }


### PR DESCRIPTION
Same thing that bugs me as my first patch, but now I'm using more of MSpec. :)
