### PR TITLE
Fixing bug causing Exceptions during setup of contexts using  [SetupForEachSpecification] to be swallowed and specifications being ignored

### DIFF
--- a/Source/Machine.Specifications/Runner/Impl/ContextRunner.cs
+++ b/Source/Machine.Specifications/Runner/Impl/ContextRunner.cs
@@ -98,6 +98,10 @@ namespace Machine.Specifications.Runner.Impl
           var runner = new SpecificationRunner(listener, options, resultSupplementers);
           result = runner.Run(specification);
         }
+        else
+        {
+            results = FailSpecification(listener, specification, result);
+        }
 
         if (specification.IsExecutable)
         {
@@ -121,5 +125,12 @@ namespace Machine.Specifications.Runner.Impl
 
       return results;
     }
+
+      private static List<Result> FailSpecification(ISpecificationRunListener listener, Specification specification, Result result)
+      {
+          listener.OnSpecificationStart(specification.GetInfo());
+          listener.OnSpecificationEnd(specification.GetInfo(), result);
+          return new List<Result> { result };
+      }
   }
 }


### PR DESCRIPTION
- fixing the following bug
  When configuring context to be established for each specification, via
  the [SetupForEachSpecification] attribute, we encountered the following
  problem:
  - an exception occurring during establish context or because did get
    swallowed
  - specifications using the context/because simply did not run and no
    failure was listed, thus they were silently ignored

I fixed this problem by adding a failing result (due to context setup)
to the listener (ISpecificationRunListener).
As a result, when the context fails this failure is listed for each
specification that uses that context.
