### PR TITLE
Added a fix to deal with multiple because block not being allowed to be overriden

### DIFF
--- a/Source/Machine.Specifications.Example.Random/ExampleSpecs.cs
+++ b/Source/Machine.Specifications.Example.Random/ExampleSpecs.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Reflection;
 
+using Machine.Specifications.Factories;
+
 namespace Machine.Specifications.Specs
 {
   public static class tag
@@ -156,6 +158,24 @@ namespace Machine.Specifications.Specs
         false.ShouldBeFalse();
     }
   }
+
+
+  public class parent_context_that_has_its_own_because_block
+  {
+    Because b = () =>
+    {
+
+    };
+
+    public class nested_context_that_has_a_because_block_which
+    {
+      Because b = () =>
+      {
+      };
+
+    }
+  }
+
 
   [Tags(tag.example)]
   public class context_with_failing_specs

--- a/Source/Machine.Specifications.Specs/Factories/ContextFactorySpecs.cs
+++ b/Source/Machine.Specifications.Specs/Factories/ContextFactorySpecs.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+
 using Machine.Specifications.Factories;
 using Machine.Specifications.Model;
 
@@ -40,10 +41,7 @@ namespace Machine.Specifications.Specs.Factories
   [Subject(typeof(ContextFactory))]
   public class when_using_nested_contexts
   {
-    Establish context = () =>
-    {
-        outerContextRan = true;
-    };
+    Establish context = () => { outerContextRan = true; };
 
     public class and_the_parent_context_has_context_blocks
     {
@@ -71,7 +69,7 @@ namespace Machine.Specifications.Specs.Factories
 
     static Context new_context;
   }
-  
+
   [Subject(typeof(ContextFactory))]
   public class when_creating_a_context_that_is_contained_within_another_context_class_and_inherits_a_concern
   {
@@ -86,7 +84,7 @@ namespace Machine.Specifications.Specs.Factories
 
     static Context new_context;
   }
-  
+
   [Subject(typeof(ContextFactory))]
   public class when_creating_a_context_that_is_contained_within_another_context_class_and_owns_a_concern
   {
@@ -101,7 +99,31 @@ namespace Machine.Specifications.Specs.Factories
 
     static Context new_context;
   }
-  
+
+  [Subject(typeof(ContextFactory))]
+  public class
+    when_creating_a_nested_context_that_has_its_own_because_block_and_its_outer_class_also_has_its_own_because_block
+  {
+    Establish context = () =>
+    {
+      ContextFactory.ChangeAllowedNumberOfBecauseBlocksTo(2);
+
+      var factory = new ContextFactory();
+      new_context =
+        factory.CreateContextFrom(
+                                  new parent_context_that_has_its_own_because_block.
+                                    nested_context_that_has_a_because_block_which());
+    };
+
+    It
+      should_be_able_to_be_created_successfully_if_a_testing_tool_has_specified_to_override_the_allowed_number_of_because_blocks
+        = () =>
+          new_context.ShouldNotBeNull();
+
+
+    static Context new_context;
+  }
+
   [Subject(typeof(ContextFactory))]
   public class when_creating_a_context_that_is_contained_within_another_context_class_without_concern
   {
@@ -122,7 +144,7 @@ namespace Machine.Specifications.Specs.Factories
   {
     static Context newContext;
 
-    Establish context = ()=>
+    Establish context = () =>
     {
       var factory = new ContextFactory();
       newContext = factory.CreateContextFrom(new context_with_tags());


### PR DESCRIPTION
In the last fix that I made, I negated the ability for my library to override the number of allowable because blocks. This test and implementation fixes that. 
