### PR TITLE
Teamcity autodetection

### DIFF
--- a/Source/Machine.Specifications.ConsoleRunner/Options.cs
+++ b/Source/Machine.Specifications.ConsoleRunner/Options.cs
@@ -37,7 +37,7 @@ namespace Machine.Specifications.ConsoleRunner
 
     [Option(null, 
       "teamcity",
-      HelpText = "Reporting for TeamCity CI integration")]
+      HelpText = "Reporting for TeamCity CI integration (autodetected)")]
     public bool TeamCityIntegration = false;
 
     [OptionList("i",

--- a/Source/Machine.Specifications.ConsoleRunner/Program.cs
+++ b/Source/Machine.Specifications.ConsoleRunner/Program.cs
@@ -48,7 +48,7 @@ namespace Machine.Specifications.ConsoleRunner
       listeners.Add(new AssemblyLocationAwareListener());
 
       ISpecificationRunListener mainListener;
-      if (options.TeamCityIntegration)
+      if (options.TeamCityIntegration || Environment.GetEnvironmentVariable("TEAMCITY_PROJECT_NAME") != null)
       {
         mainListener = new TeamCityReporter(_console.WriteLine, timingListener);
       }


### PR DESCRIPTION
Now execution inside teamcity is autodetected in the console runner application so in scenarios with teamcity is optional to pass the --teamcity parameter.
