### PR TITLE
Bug Fix for ShouldBeLike

### DIFF
--- a/Source/Machine.Specifications.Specs/ShouldBeLikeSpecs.cs
+++ b/Source/Machine.Specifications.Specs/ShouldBeLikeSpecs.cs
@@ -180,4 +180,46 @@ namespace Machine.Specifications.Specs
       It should_throw = () => Exception.ShouldBeOfType<SpecificationException>();
     }
   }
+
+  [Subject(typeof(ShouldExtensionMethods))]
+  public class when_asserting_that_two_objects_of_the_same_concrete_type_are_like_each_other
+  {
+    static Exception Exception;
+    static Dummy Obj1;
+    static Dummy Obj2;
+
+    Establish context = () => { Obj1 = new Dummy {Prop1 = "test"}; };
+
+    class Dummy
+    {
+      public string Prop1 { get; set; }
+    }
+
+    public class and_the_objects_are_similar
+    {
+      Establish context = () => { Obj2 = new Dummy {Prop1 = "test"}; };
+
+      Because of = () => { Exception = Catch.Exception(() => Obj1.ShouldBeLike(Obj2)); };
+
+      It should_not_throw = () => Exception.ShouldBeNull();
+    }
+
+    public class and_the_objects_are_different
+    {
+      Establish context = () => { Obj2 = new Dummy {Prop1 = "different"}; };
+
+      Because of = () => { Exception = Catch.Exception(() => Obj1.ShouldBeLike(Obj2)); };
+
+      It should_throw = () => Exception.ShouldBeOfType<SpecificationException>();
+    }
+
+    public class and_the_objects_are_different_and_have_null_values
+    {
+      Establish context = () => { Obj2 = new Dummy {Prop1 = null}; };
+
+      Because of = () => { Exception = Catch.Exception(() => Obj1.ShouldBeLike(Obj2)); };
+
+      It should_throw_a_specification_exception = () => Exception.ShouldBeOfType<SpecificationException>();
+    }
+  }
 }

--- a/Source/Machine.Specifications/ExtensionMethods.cs
+++ b/Source/Machine.Specifications/ExtensionMethods.cs
@@ -610,8 +610,15 @@ entire list: {1}",
 
     static IEnumerable<SpecificationException> ShouldBeLikeInternal(object obj, object expected, string nodeName)
     {
-      var expectedNode = ObjectGraphHelper.GetGraph(expected);
-      var nodeType = expectedNode.GetType();
+      ObjectGraphHelper.INode expectedNode = null;
+      var nodeType = typeof(ObjectGraphHelper.LiteralNode);
+
+      if (expected != null)
+      {
+          expectedNode = ObjectGraphHelper.GetGraph(expected);
+          nodeType = expectedNode.GetType();
+      }
+      
       if (nodeType == typeof(ObjectGraphHelper.LiteralNode))
       {
         try


### PR DESCRIPTION
The ShouldBeLike extension method is a wonderful addition to the ShouldExtensionMethods class.  I've noticed, however, that when comparing two objects of the same type (neither is an anonymous object) that if any of the properties were set to null a NullReferenceException was thrown, which meant that the test always failed.  I would expect the comparison to succeed if both objects shared the same values for corresponding properties regardless of whether the values are null or otherwise.  The exception was being thrown in a recursive call to ShouldExtensionMethods.ShouldBeLikeInternal(...).  This pull request addresses this concern.  I included the specs I wrote to expose the behavior as well as the fix in the ShouldBeLikeInternal method.  Let me know what you think.
