### PR TITLE
Custom delegate types

### DIFF
--- a/Source/Machine.Specifications.ConsoleRunner/RunListener.cs
+++ b/Source/Machine.Specifications.ConsoleRunner/RunListener.cs
@@ -89,7 +89,7 @@ namespace Machine.Specifications.ConsoleRunner
 
     public void OnSpecificationStart(SpecificationInfo specification)
     {
-      WriteVerbose("» " + specification.Name);
+      WriteVerbose("» " + specification.Leader + " " + specification.Name);
     }
 
     public void OnSpecificationEnd(SpecificationInfo specification, Result result)

--- a/Source/Machine.Specifications.Reporting.Specs/Generation/Spark/GenerateSparkHtmlReportRunListenerSpecs.cs
+++ b/Source/Machine.Specifications.Reporting.Specs/Generation/Spark/GenerateSparkHtmlReportRunListenerSpecs.cs
@@ -23,7 +23,7 @@ namespace Machine.Specifications.Reporting.Specs.Generation.Spark
 
         var assembly = new AssemblyInfo("assembly", "location");
         var context = new ContextInfo("conext", "concern", "System.Type", "System", "mscorlib");
-        var specification = new SpecificationInfo("spec", "System.Type", "field");
+        var specification = new SpecificationInfo("it", "spec", "System.Type", "field");
 
         Listener.OnRunStart();
         Listener.OnAssemblyStart(assembly);

--- a/Source/Machine.Specifications.Reporting.Specs/Generation/Spark/SparkRendererSpecs.cs
+++ b/Source/Machine.Specifications.Reporting.Specs/Generation/Spark/SparkRendererSpecs.cs
@@ -50,18 +50,18 @@ namespace Machine.Specifications.Reporting.Specs.Generation.Spark
         Report = Run(Assembly("assembly 2",
                               Concern("a 2 concern 2",
                                       Context("a 2 c 2 context 2",
-                                              Spec("a 2 c 2 c 2 specification 2", Result.Pass()),
-                                              Spec("a 2 c 2 c 2 specification 1", Result.Ignored())
+                                              Spec("it", "a 2 c 2 c 2 specification 2", Result.Pass()),
+                                              Spec("it", "a 2 c 2 c 2 specification 1", Result.Ignored())
                                         ),
                                       Context("a 2 c 2 context 1",
-                                              Spec("a 2 c 2 c 1 specification 2",
+                                              Spec("it", "a 2 c 2 c 1 specification 2",
                                                    Result.Failure(PrepareException())),
-                                              Spec("a 2 c 2 c 1 specification 1", Result.NotImplemented())
+                                              Spec("it", "a 2 c 2 c 1 specification 1", Result.NotImplemented())
                                         )
                                 ),
                               Concern("a 2 concern 1",
                                       Context("a 2 c 1 context 2",
-                                              Spec("a 2 c 1 c 2 specification 2",
+                                              Spec("it", "a 2 c 1 c 2 specification 2",
                                                    Result.Supplement(Result.Pass(),
                                                                      "the supplement",
                                                                      new Dictionary<string, string>
@@ -72,34 +72,34 @@ namespace Machine.Specifications.Reporting.Specs.Generation.Spark
                                                                        { "img-should-fail-copy", @"C:\some\html\image-should-fail-copy" },
                                                                        { "html-should-fail-copy", @"C:\some\html\file-should-fail-copy" }
                                                                      })),
-                                              Spec("a 2 c 1 c 2 specification 1", Result.Pass())
+                                              Spec("it", "a 2 c 1 c 2 specification 1", Result.Pass())
                                         ),
                                       Context("a 2 c 1 context 1",
-                                              Spec("a 2 c 1 c 1 specification 2", Result.Pass()),
-                                              Spec("a 2 c 1 c 1 specification 1",
+                                              Spec("it", "a 2 c 1 c 1 specification 2", Result.Pass()),
+                                              Spec("it", "a 2 c 1 c 1 specification 1",
                                                    Result.Failure(PrepareException()))
                                         )
                                 )),
                      Assembly("assembly 1",
                               Concern("a 1 concern 2",
                                       Context("a 1 c 2 context 2",
-                                              Spec("a 1 c 2 c 2 specification 2", Result.NotImplemented()),
-                                              Spec("a 1 c 2 c 2 specification 1", Result.Pass())
+                                              Spec("it", "a 1 c 2 c 2 specification 2", Result.NotImplemented()),
+                                              Spec("it", "a 1 c 2 c 2 specification 1", Result.Pass())
                                         ),
                                       Context("a 1 c 2 context 1",
-                                              Spec("a 1 c 2 c 1 specification 2", Result.Pass()),
-                                              Spec("a 1 c 2 c 1 specification 1",
+                                              Spec("it", "a 1 c 2 c 1 specification 2", Result.Pass()),
+                                              Spec("it", "a 1 c 2 c 1 specification 1",
                                                    Result.Failure(PrepareException()))
                                         )
                                 ),
                               Concern("a 1 concern 1",
                                       Context("a 1 c 1 context 2",
-                                              Spec("a 1 c 1 c 2 specification 2", Result.Pass()),
-                                              Spec("a 1 c 1 c 2 specification 1", Result.NotImplemented())
+                                              Spec("it", "a 1 c 1 c 2 specification 2", Result.Pass()),
+                                              Spec("it", "a 1 c 1 c 2 specification 1", Result.NotImplemented())
                                         ),
                                       Context("a 1 c 1 context 1",
-                                              Spec("a 1 c 1 c 1 specification 2", Result.Pass()),
-                                              Spec("a 1 c 1 c 1 specification 1", Result.Pass())
+                                              Spec("it", "a 1 c 1 c 1 specification 2", Result.Pass()),
+                                              Spec("it", "a 1 c 1 c 1 specification 1", Result.Pass())
                                         )
                                 )
                        )

--- a/Source/Machine.Specifications.Reporting.Specs/ReportSpecs.cs
+++ b/Source/Machine.Specifications.Reporting.Specs/ReportSpecs.cs
@@ -26,9 +26,9 @@ namespace Machine.Specifications.Reporting.Specs
       return new Context(name, specifications);
     }
 
-    protected static Specification Spec(string name, Result result)
+    protected static Specification Spec(string leader, string name, Result result)
     {
-      return new Specification(name, result) { Id = Guid.NewGuid().ToString() };
+      return new Specification(leader, name, result) { Id = Guid.NewGuid().ToString() };
     }
 
     protected static Exception PrepareException()

--- a/Source/Machine.Specifications.Reporting.Specs/Visitors/FailedSpecificationLinkerSpecs.cs
+++ b/Source/Machine.Specifications.Reporting.Specs/Visitors/FailedSpecificationLinkerSpecs.cs
@@ -19,26 +19,26 @@ namespace Machine.Specifications.Reporting.Specs.Visitors
       {
         Linker = new FailedSpecificationLinker();
 
-        First = Spec("a 1 c 1 c 1 specification 1", Result.Failure(new Exception()));
-        Second = Spec("a 2 c 1 c 1 specification 1", Result.Failure(new Exception()));
-        Last = Spec("a 2 c 1 c 2 specification 1", Result.Failure(new Exception()));
+        First = Spec("it", "a 1 c 1 c 1 specification 1", Result.Failure(new Exception()));
+        Second = Spec("it", "a 2 c 1 c 1 specification 1", Result.Failure(new Exception()));
+        Last = Spec("it", "a 2 c 1 c 2 specification 1", Result.Failure(new Exception()));
 
         Report = Run(Assembly("assembly 1",
                               Concern("a 1 concern 1",
                                       Context("a 1 c 1 context 1",
                                               First,
-                                              Spec("a 1 c 1 c 1 specification 2", Result.Pass())
+                                              Spec("it", "a 1 c 1 c 1 specification 2", Result.Pass())
                                         )
                                 )
                        ),
                      Assembly("assembly 2",
                               Concern("a 2 concern 1",
                                       Context("a 2 c 1 context 1",
-                                              Spec("a 2 c 1 c 1 specification 2", Result.Pass()),
+                                              Spec("it", "a 2 c 1 c 1 specification 2", Result.Pass()),
                                               Second),
                                       Context("a 2 c 1 context 2",
                                               Last,
-                                              Spec("a 2 c 1 c 2 specification 2", Result.Pass()))))
+                                              Spec("it", "a 2 c 1 c 2 specification 2", Result.Pass()))))
           );
       };
 

--- a/Source/Machine.Specifications.Reporting.Specs/Visitors/FileBasedResultSupplementPreparationSpecs.cs
+++ b/Source/Machine.Specifications.Reporting.Specs/Visitors/FileBasedResultSupplementPreparationSpecs.cs
@@ -27,7 +27,7 @@ namespace Machine.Specifications.Reporting.Specs.Visitors
       Report = Run(Assembly("assembly 1",
                             Concern("a 1 concern 1",
                                     Context("a 1 c 1 context 1",
-                                            Spec("a 1 c 1 c 1 specification 2", Result.Pass())
+                                            Spec("it", "a 1 c 1 c 1 specification 2", Result.Pass())
                                       )
                               )
                      ));
@@ -53,7 +53,7 @@ namespace Machine.Specifications.Reporting.Specs.Visitors
         Preparation = new FileBasedResultSupplementPreparation(MockRepository.GenerateStub<IFileSystem>());
         Preparation.Initialize(new VisitorContext { ResourcePathCreator = () => @"C:\report\resources" });
 
-        Images = Spec("a 1 c 1 c 1 specification 1",
+        Images = Spec("it", "a 1 c 1 c 1 specification 1",
                       Result.Supplement(Result.Pass(),
                                         "Images",
                                         new Dictionary<string, string>
@@ -62,7 +62,7 @@ namespace Machine.Specifications.Reporting.Specs.Visitors
                                           { "img-another-image", @"C:\some\other\image.png" }
                                         }));
 
-        HtmlFiles = Spec("a 2 c 1 c 1 specification 1",
+        HtmlFiles = Spec("it", "a 2 c 1 c 1 specification 1",
                          Result.Supplement(Result.Pass(),
                                            "HTML",
                                            new Dictionary<string, string>
@@ -71,7 +71,7 @@ namespace Machine.Specifications.Reporting.Specs.Visitors
                                              { "html-another-file", @"C:\some\other\file.html" }
                                            }));
 
-        Texts = Spec("a 2 c 1 c 2 specification 1",
+        Texts = Spec("it", "a 2 c 1 c 2 specification 1",
                      Result.Supplement(Result.Pass(),
                                        "Text",
                                        new Dictionary<string, string>
@@ -84,18 +84,18 @@ namespace Machine.Specifications.Reporting.Specs.Visitors
                               Concern("a 1 concern 1",
                                       Context("a 1 c 1 context 1",
                                               Images,
-                                              Spec("a 1 c 1 c 1 specification 2", Result.Pass())
+                                              Spec("it", "a 1 c 1 c 1 specification 2", Result.Pass())
                                         )
                                 )
                        ),
                      Assembly("assembly 2",
                               Concern("a 2 concern 1",
                                       Context("a 2 c 1 context 1",
-                                              Spec("a 2 c 1 c 1 specification 2", Result.Pass()),
+                                              Spec("it", "a 2 c 1 c 1 specification 2", Result.Pass()),
                                               HtmlFiles),
                                       Context("a 2 c 1 context 2",
                                               Texts,
-                                              Spec("a 2 c 1 c 2 specification 2", Result.Pass())))));
+                                              Spec("it", "a 2 c 1 c 2 specification 2", Result.Pass())))));
       };
 
     Because of = () => Preparation.Visit(Report);
@@ -128,7 +128,7 @@ namespace Machine.Specifications.Reporting.Specs.Visitors
         Preparation = new FileBasedResultSupplementPreparation(fileSystem);
         Preparation.Initialize(new VisitorContext { ResourcePathCreator = () => @"C:\report\resources" });
 
-        Failing = Spec("a 1 c 1 c 1 specification 1",
+        Failing = Spec("it", "a 1 c 1 c 1 specification 1",
                        Result.Supplement(Result.Pass(),
                                          "Failing Images and Text",
                                          new Dictionary<string, string>
@@ -186,7 +186,7 @@ namespace Machine.Specifications.Reporting.Specs.Visitors
         Preparation = new FileBasedResultSupplementPreparation(fileSystem);
         Preparation.Initialize(new VisitorContext { ResourcePathCreator = () => @"C:\report\resources" });
 
-        Failing = Spec("a 1 c 1 c 1 specification 1",
+        Failing = Spec("it", "a 1 c 1 c 1 specification 1",
                        Result.Supplement(Result.Pass(),
                                          "Failing Images and Text",
                                          new Dictionary<string, string>

--- a/Source/Machine.Specifications.Reporting.Specs/Visitors/IgnoredSpecificationLinkerSpecs.cs
+++ b/Source/Machine.Specifications.Reporting.Specs/Visitors/IgnoredSpecificationLinkerSpecs.cs
@@ -17,26 +17,26 @@ namespace Machine.Specifications.Reporting.Specs.Visitors
       {
         Linker = new IgnoredSpecificationLinker();
 
-        First = Spec("a 1 c 1 c 1 specification 1", Result.Ignored());
-        Second = Spec("a 2 c 1 c 1 specification 1", Result.Ignored());
-        Last = Spec("a 2 c 1 c 2 specification 1", Result.Ignored());
+        First = Spec("it", "a 1 c 1 c 1 specification 1", Result.Ignored());
+        Second = Spec("it", "a 2 c 1 c 1 specification 1", Result.Ignored());
+        Last = Spec("it", "a 2 c 1 c 2 specification 1", Result.Ignored());
 
         Report = Run(Assembly("assembly 1",
                               Concern("a 1 concern 1",
                                       Context("a 1 c 1 context 1",
                                               First,
-                                              Spec("a 1 c 1 c 1 specification 2", Result.Pass())
+                                              Spec("it", "a 1 c 1 c 1 specification 2", Result.Pass())
                                         )
                                 )
                        ),
                      Assembly("assembly 2",
                               Concern("a 2 concern 1",
                                       Context("a 2 c 1 context 1",
-                                              Spec("a 2 c 1 c 1 specification 2", Result.Pass()),
+                                              Spec("it", "a 2 c 1 c 1 specification 2", Result.Pass()),
                                               Second),
                                       Context("a 2 c 1 context 2",
                                               Last,
-                                              Spec("a 2 c 1 c 2 specification 2", Result.Pass()))))
+                                              Spec("it", "a 2 c 1 c 2 specification 2", Result.Pass()))))
           );
       };
 

--- a/Source/Machine.Specifications.Reporting.Specs/Visitors/NotImplementedSpecificationLinkerSpecs.cs
+++ b/Source/Machine.Specifications.Reporting.Specs/Visitors/NotImplementedSpecificationLinkerSpecs.cs
@@ -17,26 +17,26 @@ namespace Machine.Specifications.Reporting.Specs.Visitors
       {
         Linker = new NotImplementedSpecificationLinker();
 
-        First = Spec("a 1 c 1 c 1 specification 1", Result.NotImplemented());
-        Second = Spec("a 2 c 1 c 1 specification 1", Result.NotImplemented());
-        Last = Spec("a 2 c 1 c 2 specification 1", Result.NotImplemented());
+        First = Spec("it", "a 1 c 1 c 1 specification 1", Result.NotImplemented());
+        Second = Spec("it", "a 2 c 1 c 1 specification 1", Result.NotImplemented());
+        Last = Spec("it", "a 2 c 1 c 2 specification 1", Result.NotImplemented());
 
         Report = Run(Assembly("assembly 1",
                               Concern("a 1 concern 1",
                                       Context("a 1 c 1 context 1",
                                               First,
-                                              Spec("a 1 c 1 c 1 specification 2", Result.Pass())
+                                              Spec("it", "a 1 c 1 c 1 specification 2", Result.Pass())
                                         )
                                 )
                        ),
                      Assembly("assembly 2",
                               Concern("a 2 concern 1",
                                       Context("a 2 c 1 context 1",
-                                              Spec("a 2 c 1 c 1 specification 2", Result.Pass()),
+                                              Spec("it", "a 2 c 1 c 1 specification 2", Result.Pass()),
                                               Second),
                                       Context("a 2 c 1 context 2",
                                               Last,
-                                              Spec("a 2 c 1 c 2 specification 2", Result.Pass()))))
+                                              Spec("it", "a 2 c 1 c 2 specification 2", Result.Pass()))))
           );
       };
 

--- a/Source/Machine.Specifications.Reporting/Generation/Spark/Templates/_Specification.spark
+++ b/Source/Machine.Specifications.Reporting/Generation/Spark/Templates/_Specification.spark
@@ -1,4 +1,4 @@
-﻿<span id="${spec.Id}">${spec.Name}</span>
+﻿<span id="${spec.Id}">${spec.Leader} ${spec.Name}</span>
 
 <if condition="spec.Status == Status.Failing">
   <div class="failure">

--- a/Source/Machine.Specifications.Reporting/Generation/SpecificationTreeListener.cs
+++ b/Source/Machine.Specifications.Reporting/Generation/SpecificationTreeListener.cs
@@ -21,7 +21,7 @@ namespace Machine.Specifications.Reporting.Generation
 
     public static Specification ToNode(this SpecificationInfo specification, Result result)
     {
-      return new Specification(specification.Name, result);
+      return new Specification(specification.Leader, specification.Name, result);
     }
   }
 

--- a/Source/Machine.Specifications.Reporting/Generation/Xml/XmlReportGenerator.cs
+++ b/Source/Machine.Specifications.Reporting/Generation/Xml/XmlReportGenerator.cs
@@ -198,6 +198,7 @@ namespace Machine.Specifications.Reporting.Generation.Xml
             break;
         }
         reportBuilder.WriteStartElement("specification");
+        reportBuilder.WriteAttributeString("leader", specification.Leader);
         reportBuilder.WriteAttributeString("name", specification.Name);
         reportBuilder.WriteAttributeString("field-name", specification.FieldName);
         reportBuilder.WriteAttributeString("status", status);

--- a/Source/Machine.Specifications.Reporting/Integration/TeamCityReporter.cs
+++ b/Source/Machine.Specifications.Reporting/Integration/TeamCityReporter.cs
@@ -113,7 +113,7 @@ namespace Machine.Specifications.Reporting.Integration
 
     protected string GetSpecificationName(SpecificationInfo specification)
     {
-      return _currentContext + " > " + specification.Name;
+      return _currentContext + " > " + specification.Leader + " " + specification.Name;
     }
   }
 }

--- a/Source/Machine.Specifications.Reporting/Model/Specification.cs
+++ b/Source/Machine.Specifications.Reporting/Model/Specification.cs
@@ -6,11 +6,13 @@ namespace Machine.Specifications.Reporting.Model
   {
     readonly ExceptionResult _exception;
     readonly string _name;
+    readonly string _leader;
     readonly Status _status;
     readonly IDictionary<string, IDictionary<string, string>> _supplements;
 
-    public Specification(string name, Result result)
+    public Specification(string leader, string name, Result result)
     {
+      _leader = leader;
       _status = result.Status;
       _exception = result.Exception;
       _supplements = result.Supplements;
@@ -21,6 +23,11 @@ namespace Machine.Specifications.Reporting.Model
     {
       get;
       set;
+    }
+
+    public string Leader
+    {
+      get { return _leader; }
     }
 
     public Status Status

--- a/Source/Machine.Specifications.Specs/AssertionSpecs.cs
+++ b/Source/Machine.Specifications.Specs/AssertionSpecs.cs
@@ -45,7 +45,7 @@ namespace Machine.Specifications.Specs
     Because of = () => { Exception = Catch.Exception(() => Ints.ShouldEachConformTo(x => x % 2 == 0)); };
 
     It should_print_the_func_description =
-      () => Exception.Message.ShouldContain("Should contain only elements conforming to: x => ((x % 2) = 0)");
+      () => Exception.Message.ShouldContain("Should contain only elements conforming to: x => ((x % 2) == 0)");
 
     It should_print_the_elements_that_did_not_match =
       () => Exception.Message.ShouldMatch(@"the following items did not meet the condition: {\s+\[1\],\s+\[3\]\s+}");

--- a/Source/Machine.Specifications/DelegateUsageAttribute.cs
+++ b/Source/Machine.Specifications/DelegateUsageAttribute.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Machine.Specifications
+{
+  [AttributeUsage(AttributeTargets.Delegate, Inherited = false, AllowMultiple = false)]
+  public sealed class DelegateUsageAttribute : Attribute
+  {
+    public DelegateUsage DelegateUsage
+    {
+      get;
+      private set;
+    }
+
+    public DelegateUsageAttribute(DelegateUsage delegateUsage)
+    {
+      DelegateUsage = delegateUsage;
+    }
+  }
+
+  public enum DelegateUsage
+  {
+    Setup = 0,
+    Act = 1,
+    Behavior = 2,
+    Assert = 3,
+    Cleanup = 4
+  }
+}

--- a/Source/Machine.Specifications/Explorers/AssemblyExplorer.cs
+++ b/Source/Machine.Specifications/Explorers/AssemblyExplorer.cs
@@ -70,9 +70,7 @@ namespace Machine.Specifications.Explorers
 
     static bool HasSpecificationMembers(Type type)
     {
-      return !type.IsAbstract &&
-             (type.GetInstanceFieldsOfType<It>().Any() ||
-              type.GetInstanceFieldsOfType(typeof(Behaves_like<>)).Any());
+      return !type.IsAbstract && type.GetInstanceFieldsOfUsage(DelegateUsage.Assert, DelegateUsage.Behavior).Any();
     }
 
     static IEnumerable<Type> EnumerateContextsIn(Assembly assembly)
@@ -80,7 +78,7 @@ namespace Machine.Specifications.Explorers
       return assembly
         .GetTypes()
         .Where(IsContext)
-        .OrderBy(t => t.Namespace);
+        .OrderBy(t => t.Namespace).ToArray();
     }
 
     public Context FindContexts(Type type)

--- a/Source/Machine.Specifications/Factories/BehaviorFactory.cs
+++ b/Source/Machine.Specifications/Factories/BehaviorFactory.cs
@@ -30,9 +30,9 @@ namespace Machine.Specifications.Factories
 
       var isIgnored = behaviorField.HasAttribute<IgnoreAttribute>() ||
                       behaviorInstance.GetType().HasAttribute<IgnoreAttribute>();
-      var behavior = new Behavior(behaviorInstance, context, isIgnored);
+      var behavior = new Behavior(behaviorField.FieldType, behaviorInstance, context, isIgnored);
 
-      var itFieldInfos = behaviorType.GetInstanceFieldsOfType<It>();
+      var itFieldInfos = behaviorType.GetInstanceFieldsOfUsage(DelegateUsage.Assert);
       CreateBehaviorSpecifications(itFieldInfos, behavior);
 
       return behavior;
@@ -50,27 +50,27 @@ namespace Machine.Specifications.Factories
 
     static void EnsureBehaviorDoesNotHaveFrameworkFieldsExceptIt(Type behaviorType)
     {
-      if (behaviorType.GetInstanceFieldsOfType<Establish>().Any())
+      if (behaviorType.GetInstanceFieldsOfUsage(DelegateUsage.Setup).Any())
       {
-        throw new SpecificationUsageException("You cannot have Establishs on Behaviors. Establish found in " +
+        throw new SpecificationUsageException("You cannot have setup actions on Behaviors. Setup action found in " +
                                               behaviorType.FullName);
       }
 
-      if (behaviorType.GetInstanceFieldsOfType<Because>().Any())
+      if (behaviorType.GetInstanceFieldsOfUsage(DelegateUsage.Act).Any())
       {
-        throw new SpecificationUsageException("You cannot have Becauses on Behaviors. Because found in " +
+        throw new SpecificationUsageException("You cannot have act actions on Behaviors. Act action found in " +
                                               behaviorType.FullName);
       }
 
-      if (behaviorType.GetInstanceFieldsOfType<Cleanup>().Any())
+      if (behaviorType.GetInstanceFieldsOfUsage(DelegateUsage.Cleanup).Any())
       {
-        throw new SpecificationUsageException("You cannot have Cleanups on Behaviors. Cleanup found in " +
+        throw new SpecificationUsageException("You cannot have cleanup actions on Behaviors. Cleanup action found in " +
                                               behaviorType.FullName);
       }
 
-      if (behaviorType.GetInstanceFieldsOfType(typeof(Behaves_like<>)).Any())
+      if (behaviorType.GetInstanceFieldsOfUsage(DelegateUsage.Behavior).Any())
       {
-        throw new SpecificationUsageException("You cannot nest Behaviors. Nested Behaviors found in " +
+        throw new SpecificationUsageException("You cannot nest behaviors. Nested behaviors found in " +
                                               behaviorType.FullName);
       }
     }

--- a/Source/Machine.Specifications/Factories/SpecificationFactory.cs
+++ b/Source/Machine.Specifications/Factories/SpecificationFactory.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using Machine.Specifications.Model;
 using Machine.Specifications.Utility;
 using Machine.Specifications.Utility.Internal;
+using System;
 
 namespace Machine.Specifications.Factories
 {
@@ -11,19 +12,19 @@ namespace Machine.Specifications.Factories
     public Specification CreateSpecification(Context context, FieldInfo specificationField)
     {
       bool isIgnored = context.IsIgnored || specificationField.HasAttribute<IgnoreAttribute>();
-      It it = (It) specificationField.GetValue(context.Instance);
+      var it = (Delegate) specificationField.GetValue(context.Instance);
       string name = specificationField.Name.ToFormat();
 
-      return new Specification(name, it, isIgnored, specificationField);
+      return new Specification(name, specificationField.FieldType, it, isIgnored, specificationField);
     }
 
     public Specification CreateSpecificationFromBehavior(Behavior behavior, FieldInfo specificationField)
     {
       bool isIgnored = behavior.IsIgnored || specificationField.HasAttribute<IgnoreAttribute>();
-      It it = (It) specificationField.GetValue(behavior.Instance);
+      var it = (Delegate) specificationField.GetValue(behavior.Instance);
       string name = specificationField.Name.ToFormat();
 
-      return new BehaviorSpecification(name, it, isIgnored, specificationField, behavior.Context, behavior);
+      return new BehaviorSpecification(name, specificationField.FieldType, it, isIgnored, specificationField, behavior.Context, behavior);
     }
   }
 }

--- a/Source/Machine.Specifications/Framework.cs
+++ b/Source/Machine.Specifications/Framework.cs
@@ -4,12 +4,17 @@ using System.Text;
 
 namespace Machine.Specifications
 {
+  [DelegateUsage(DelegateUsage.Setup)]
   public delegate void Establish();
 
+  [DelegateUsage(DelegateUsage.Act)]
   public delegate void Because();
 
+  [DelegateUsage(DelegateUsage.Assert)]
   public delegate void It();
+  [DelegateUsage(DelegateUsage.Behavior)]
   public delegate void Behaves_like<TBehavior>();
 
+  [DelegateUsage(DelegateUsage.Cleanup)]
   public delegate void Cleanup();
 }

--- a/Source/Machine.Specifications/Machine.Specifications.csproj
+++ b/Source/Machine.Specifications/Machine.Specifications.csproj
@@ -79,6 +79,7 @@
     <Compile Include="ComparerStrategies\DefaultComparer.cs" />
     <Compile Include="ComparerStrategies\EnumerableComparer.cs" />
     <Compile Include="ComparerStrategies\EquatableComparer.cs" />
+    <Compile Include="DelegateUsageAttribute.cs" />
     <Compile Include="ExtensionMethods.cs" />
     <Compile Include="Factories\BehaviorFactory.cs" />
     <Compile Include="Factories\ITagExtractor.cs" />

--- a/Source/Machine.Specifications/Model/Behavior.cs
+++ b/Source/Machine.Specifications/Model/Behavior.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using Machine.Specifications.Utility.Internal;
+using System;
 
 namespace Machine.Specifications.Model
 {
@@ -7,13 +9,20 @@ namespace Machine.Specifications.Model
     readonly Context _context;
     readonly object _instance;
     readonly List<Specification> _specifications;
+    readonly string _leader;
 
-    public Behavior(object instance, Context context, bool isIgnored)
+    public Behavior(Type fieldType, object instance, Context context, bool isIgnored)
     {
+      _leader = fieldType.ToFormat();
       _instance = instance;
       _context = context;
       IsIgnored = isIgnored;
       _specifications = new List<Specification>();
+    }
+
+    public string Leader
+    {
+      get { return _leader; }
     }
 
     public bool IsIgnored

--- a/Source/Machine.Specifications/Model/BehaviorSpecification.cs
+++ b/Source/Machine.Specifications/Model/BehaviorSpecification.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Reflection;
 
 using Machine.Specifications.Utility;
+using System;
 
 namespace Machine.Specifications.Model
 {
@@ -12,12 +13,13 @@ namespace Machine.Specifications.Model
     readonly ConventionMapper _mapper;
 
     public BehaviorSpecification(string name,
-                                 It it,
+                                 Type fieldType,
+                                 Delegate it,
                                  bool isIgnored,
                                  FieldInfo fieldInfo,
                                  Context context,
                                  Behavior behavior)
-      : base(name, it, isIgnored, fieldInfo)
+      : base(name, fieldType, it, isIgnored, fieldInfo)
     {
       _contextInstance = context.Instance;
       _behaviorInstance = behavior.Instance;

--- a/Source/Machine.Specifications/Model/Context.cs
+++ b/Source/Machine.Specifications/Model/Context.cs
@@ -13,10 +13,9 @@ namespace Machine.Specifications.Model
     readonly object _instance;
 
     readonly Subject _subject;
-    readonly IEnumerable<Establish> _contextClauses;
-    readonly IEnumerable<Because> _becauseClauses;
-
-    readonly IEnumerable<Cleanup> _cleanupClauses;
+    readonly IEnumerable<Delegate> _contextClauses;
+    readonly IEnumerable<Delegate> _becauseClauses;
+    readonly IEnumerable<Delegate> _cleanupClauses;
 
     readonly IEnumerable<Tag> _tags;
 
@@ -50,9 +49,9 @@ namespace Machine.Specifications.Model
 
     public Context(Type type,
                    object instance,
-                   IEnumerable<Establish> contextClauses,
-                   IEnumerable<Because> becauseClauses,
-                   IEnumerable<Cleanup> cleanupClauses,
+                   IEnumerable<Delegate> contextClauses,
+                   IEnumerable<Delegate> becauseClauses,
+                   IEnumerable<Delegate> cleanupClauses,
                    Subject subject,
                    bool isIgnored,
                    IEnumerable<Tag> tags,

--- a/Source/Machine.Specifications/Model/Specification.cs
+++ b/Source/Machine.Specifications/Model/Specification.cs
@@ -3,15 +3,17 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using Machine.Specifications.Utility.Internal;
 
 namespace Machine.Specifications.Model
 {
   public class Specification
   {
     readonly string _name;
-    readonly It _it;
+    readonly Delegate _it;
     readonly bool _isIgnored;
     readonly FieldInfo _fieldInfo;
+    readonly string _leader;
 
     public FieldInfo FieldInfo
     {
@@ -28,8 +30,14 @@ namespace Machine.Specifications.Model
       get { return _isIgnored; }
     }
 
-    public Specification(string name, It it, bool isIgnored, FieldInfo fieldInfo)
+    public string Leader
     {
+      get { return _leader; }
+    }
+
+    public Specification(string name, Type fieldType, Delegate it, bool isIgnored, FieldInfo fieldInfo)
+    {
+      _leader = fieldType.ToFormat();
       _name = name;
       _it = it;
       _isIgnored = isIgnored;
@@ -72,7 +80,7 @@ namespace Machine.Specifications.Model
 
     protected virtual void InvokeSpecificationField()
     {
-      _it.Invoke();
+      _it.DynamicInvoke();
     }
   }
 }

--- a/Source/Machine.Specifications/Runner/Impl/InfoExtensions.cs
+++ b/Source/Machine.Specifications/Runner/Impl/InfoExtensions.cs
@@ -23,7 +23,7 @@ namespace Machine.Specifications.Runner.Impl
 
     public static SpecificationInfo GetInfo(this Specification specification)
     {
-      return new SpecificationInfo(specification.Name, specification.FieldInfo.DeclaringType.FullName, specification.FieldInfo.Name);
+      return new SpecificationInfo(specification.Leader, specification.Name, specification.FieldInfo.DeclaringType.FullName, specification.FieldInfo.Name);
     }
   }
 }

--- a/Source/Machine.Specifications/Runner/SpecificationInfo.cs
+++ b/Source/Machine.Specifications/Runner/SpecificationInfo.cs
@@ -8,12 +8,14 @@ namespace Machine.Specifications.Runner
   [Serializable]
   public class SpecificationInfo
   {
+    public string Leader { get; set; }
     public string Name { get; set; }
     public string ContainingType { get; set; }
     public string FieldName { get; set; }
 
-    public SpecificationInfo(string name, string containingType, string fieldName)
+    public SpecificationInfo(string leader, string name, string containingType, string fieldName)
     {
+      Leader = leader;
       Name = name;
       ContainingType = containingType;
       FieldName = fieldName;

--- a/Source/Machine.Specifications/Utility/Internal/Naming.cs
+++ b/Source/Machine.Specifications/Utility/Internal/Naming.cs
@@ -1,4 +1,8 @@
-﻿using System.Text.RegularExpressions;
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
 
 namespace Machine.Specifications.Utility.Internal
 {
@@ -6,6 +10,21 @@ namespace Machine.Specifications.Utility.Internal
   {
     static readonly Regex QuoteRegex = new Regex(@"(?<quoted>__(?<inner>\w+?)__)",
                                                  RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    public static string ToFormat(this Type type)
+    {
+      while (true)
+      {
+        var args = type.GetGenericArguments();
+        if (args.Length == 0 || args.Where(x => x.IsGenericParameter).Any()) break;
+        type = type.GetGenericTypeDefinition();
+      }
+      var typeName = type.Name;
+      var index = typeName.IndexOf('`');
+      if (index > 0) typeName = typeName.Substring(0, index);
+      if (typeName.Length > 0) typeName = char.ToLower(typeName[0]) + typeName.Substring(1);
+      return ToFormat(typeName);
+    }
 
     public static string ToFormat(this string name)
     {

--- a/Source/Machine.Specifications/Utility/RandomExtensionMethods.cs
+++ b/Source/Machine.Specifications/Utility/RandomExtensionMethods.cs
@@ -15,9 +15,9 @@ namespace Machine.Specifications.Utility
       }
     }
 
-    internal static void InvokeAll(this IEnumerable<Establish> contextActions)
+    internal static void InvokeAll(this IEnumerable<Delegate> contextActions, params object[] args)
     {
-      contextActions.AllNonNull().Select<Establish, Action>(x => x.Invoke).InvokeAll();
+      contextActions.AllNonNull().Select<Delegate, Action>(x => () => x.DynamicInvoke(args)).InvokeAll();
     }
 
     static IEnumerable<T> AllNonNull<T>(this IEnumerable<T> elements) where T : class
@@ -28,16 +28,6 @@ namespace Machine.Specifications.Utility
     static void InvokeAll(this IEnumerable<Action> actions)
     {
       actions.Each(x => x());
-    }
-
-    internal static void InvokeAll(this IEnumerable<Because> becauseActions)
-    {
-      becauseActions.AllNonNull().Select<Because, Action>(x => x.Invoke).InvokeAll();
-    }
-
-    internal static void InvokeAll(this IEnumerable<Cleanup> contextActions)
-    {
-      contextActions.AllNonNull().Select<Cleanup, Action>(x => x.Invoke).InvokeAll();
     }
 
     internal static bool HasAttribute<TAttribute>(this ICustomAttributeProvider attributeProvider)

--- a/Source/Machine.Specifications/Utility/ReflectionHelper.cs
+++ b/Source/Machine.Specifications/Utility/ReflectionHelper.cs
@@ -19,14 +19,21 @@ namespace Machine.Specifications.Utility
         .Where(x => !x.IsPrivate);
     }
 
-    public static IEnumerable<FieldInfo> GetInstanceFieldsOfType<T>(this Type type)
+    public static IEnumerable<FieldInfo> GetInstanceFieldsOfUsage(this Type type, DelegateUsage usage)
     {
-      return GetInstanceFields(type).Where(x => x.FieldType == typeof(T));
+      return GetInstanceFields(type).Where(x => GetDelegateUsage(x) == usage);
     }
 
-    public static IEnumerable<FieldInfo> GetInstanceFieldsOfType(this Type type, Type fieldType)
+    public static IEnumerable<FieldInfo> GetInstanceFieldsOfUsage(this Type type, params DelegateUsage[] usages)
     {
-      return GetInstanceFields(type).Where(x => x.FieldType.IsOfType(fieldType));
+      if (usages == null || usages.Length == 0) throw new ArgumentNullException("usages");
+      var result = Enumerable.Empty<FieldInfo>();
+      var fields = GetInstanceFields(type);
+      foreach (var usage in usages)
+      {
+        result = result.Union(fields.Where(x => GetDelegateUsage(x) == usage));
+      }
+      return result;
     }
 
     public static FieldInfo GetStaticProtectedOrInheritedFieldNamed(this Type type, string fieldName)
@@ -34,13 +41,42 @@ namespace Machine.Specifications.Utility
       return type.GetStaticProtectedOrInheritedFields().Where(x => x.Name == fieldName).SingleOrDefault();
     }
 
-    public static bool IsOfType(this Type type, Type fieldType)
+    public static bool IsOfUsage(this FieldInfo fieldInfo, DelegateUsage usage)
     {
-      if (type.IsGenericType)
+      return GetDelegateUsage(fieldInfo) == usage;
+    }
+
+    public static DelegateUsage? GetDelegateUsage(this FieldInfo fieldInfo)
+    {
+      var fieldType = fieldInfo.FieldType;
+
+      var attrs = fieldType.GetCustomAttributes(typeof(DelegateUsageAttribute), false);
+      if (attrs.Length == 0) return null;
+      var usage = ((DelegateUsageAttribute)attrs[0]).DelegateUsage;
+      var invoke = fieldType.GetMethod("Invoke");
+
+      // Do some validation to prevent messages with no indication of the cause of the problem later on.
+      if (invoke == null) throw new InvalidOperationException(string.Format("The delegate type {0} does not have an invoke method.", fieldType));
+      if (invoke.GetParameters().Length != 0)
+        throw new InvalidOperationException(string.Format("{0} delegates require 0 parameters, {1} has {2}.", usage, fieldType, invoke.GetParameters().Length));
+
+      switch (usage)
       {
-        return type.GetGenericTypeDefinition() == fieldType;
+        case DelegateUsage.Behavior:
+          if (!fieldType.IsGenericType)
+            throw new InvalidOperationException(string.Format("{0} delegates need to be generic types with 1 parameter. {1} is not a generic type.", usage, fieldType));
+          if (fieldType.GetGenericArguments().Length != 1)
+            throw new InvalidOperationException(string.Format("{0} delegates need to be generic types with 1 parameter. {1} has {2} parameters.", usage, fieldType, fieldType.GetGenericParameterConstraints().Length));
+          break;
+        case DelegateUsage.Setup:
+        case DelegateUsage.Act:
+        case DelegateUsage.Assert:
+        case DelegateUsage.Cleanup:
+          // Only the parameters need to be validated.
+          break;
       }
-      return type == fieldType;
+
+      return usage;
     }
   }
 }


### PR DESCRIPTION
This adds support for end-developer defined delegates types. For example:

``` c#
[DelegateUsage(DelegateUsage.Act)]
public delegate void When();
/// ...
When the_user_does_something_stupid = () => user.StupidAction();
```

The usages have a required method signature:
- At the very minimum, no parameters.
- Behaviors need a single generic argument.

In addition because there are these non-standard delegates, the output from the console runner has been changed to reflect the new `Leader` field. `Leader` contains a pretty-formatted version of the field type (e.g. `Behaves_like<Monkey>` yields "behaves like"). None of the other runners have been updated.
