### PR TITLE
ShouldBeLike for objects with sequences (arrays, IEnumerable<T>, etc...)

### DIFF
--- a/Source/Machine.Specifications.Specs/Utility/ObjectGraphHelperSpecs.cs
+++ b/Source/Machine.Specifications.Specs/Utility/ObjectGraphHelperSpecs.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 
 using Machine.Specifications.Utility;
 
@@ -89,7 +90,7 @@ namespace Machine.Specifications.Specs.Utility
     }
 
     [Subject(typeof(ObjectGraphHelper))]
-    public class when_getting_an_array_graph
+    public class when_getting_a_sequence_graph_with_an_array
     {
         static object _array;
         static ObjectGraphHelper.INode _result;
@@ -100,17 +101,43 @@ namespace Machine.Specifications.Specs.Utility
         {
             Establish ctx = () => _array = new string[] {};
 
-            It should_return_an_array_node = () => _result.ShouldBeOfType<ObjectGraphHelper.ArrayNode>();
-            It should_be_empty = () => ((ObjectGraphHelper.ArrayNode) _result).ValueGetters.ShouldBeEmpty();
+            It should_return_an_array_node = () => _result.ShouldBeOfType<ObjectGraphHelper.SequenceNode>();
+            It should_be_empty = () => ((ObjectGraphHelper.SequenceNode) _result).ValueGetters.ShouldBeEmpty();
         }
         
         public class with_values
         {
             Establish ctx = () => _array = new[] {"value1", "value2"};
 
-            It should_return_an_array_node = () => _result.ShouldBeOfType<ObjectGraphHelper.ArrayNode>();
-            It should_contain_value1 = () => ((ObjectGraphHelper.ArrayNode) _result).ValueGetters.ElementAt(0)().ShouldEqual("value1");
-            It should_contain_value2 = () => ((ObjectGraphHelper.ArrayNode) _result).ValueGetters.ElementAt(1)().ShouldEqual("value2");
+            It should_return_an_array_node = () => _result.ShouldBeOfType<ObjectGraphHelper.SequenceNode>();
+            It should_contain_value1 = () => ((ObjectGraphHelper.SequenceNode) _result).ValueGetters.ElementAt(0)().ShouldEqual("value1");
+            It should_contain_value2 = () => ((ObjectGraphHelper.SequenceNode) _result).ValueGetters.ElementAt(1)().ShouldEqual("value2");
+        }
+    }
+
+    [Subject(typeof(ObjectGraphHelper))]
+    public class when_getting_a_sequence_graph_with_an_IEnumerable
+    {
+        static IEnumerable<string> _sequence;
+        static ObjectGraphHelper.INode _result;
+
+        Because of = () => _result = ObjectGraphHelper.GetGraph(_sequence);
+
+        public class when_no_values
+        {
+            Establish ctx = () => _sequence = new List<string>();
+
+            It should_return_an_array_node = () => _result.ShouldBeOfType<ObjectGraphHelper.SequenceNode>();
+            It should_be_empty = () => ((ObjectGraphHelper.SequenceNode)_result).ValueGetters.ShouldBeEmpty();
+        }
+
+        public class when_values
+        {
+            Establish ctx = () => _sequence = new List<string> { "value1", "value2" };
+
+            It should_return_an_array_node = () => _result.ShouldBeOfType<ObjectGraphHelper.SequenceNode>();
+            It should_contain_value1 = () => ((ObjectGraphHelper.SequenceNode)_result).ValueGetters.ElementAt(0)().ShouldEqual("value1");
+            It should_contain_value2 = () => ((ObjectGraphHelper.SequenceNode)_result).ValueGetters.ElementAt(1)().ShouldEqual("value2");
         }
     }
 

--- a/Source/Machine.Specifications/ExtensionMethods.cs
+++ b/Source/Machine.Specifications/ExtensionMethods.cs
@@ -299,7 +299,7 @@ does contain: {2}",
       if (parameters.Any())
       {
         return
-          new SpecificationException(string.Format(message,
+          new SpecificationException(string.Format(message.EnsureSafeFormat(),
                                                    parameters.Select(x => x.ToUsefulString()).Cast<object>().ToArray()));
       }
       return new SpecificationException(message);
@@ -632,23 +632,23 @@ entire list: {1}",
 
         return Enumerable.Empty<SpecificationException>();
       }
-      else if (nodeType == typeof(ObjectGraphHelper.ArrayNode))
+      else if (nodeType == typeof(ObjectGraphHelper.SequenceNode))
       {
         var actualNode = ObjectGraphHelper.GetGraph(obj);
-        if (actualNode.GetType() != typeof(ObjectGraphHelper.ArrayNode))
+        if (actualNode.GetType() != typeof(ObjectGraphHelper.SequenceNode))
         {
-          var errorMessage = string.Format("  Expected: Array{0}  But was:  {1}", Environment.NewLine, obj.GetType());
+          var errorMessage = string.Format("  Expected: Array or Sequence{0}  But was:  {1}", Environment.NewLine, obj.GetType());
           return new[] {NewException(string.Format("{{0}}:{0}{1}", Environment.NewLine, errorMessage), nodeName)};
         }
 
-        var expectedValues = ((ObjectGraphHelper.ArrayNode) expectedNode).ValueGetters;
-        var actualValues = ((ObjectGraphHelper.ArrayNode) actualNode).ValueGetters;
+        var expectedValues = ((ObjectGraphHelper.SequenceNode) expectedNode).ValueGetters;
+        var actualValues = ((ObjectGraphHelper.SequenceNode) actualNode).ValueGetters;
 
         var expectedCount = expectedValues.Count();
         var actualCount = actualValues.Count();
         if (expectedCount != actualCount)
         {
-          var errorMessage = string.Format("  Expected: Array length of {1}{0}  But was:  {2}", Environment.NewLine, expectedCount, actualCount);
+          var errorMessage = string.Format("  Expected: Sequence length of {1}{0}  But was:  {2}", Environment.NewLine, expectedCount, actualCount);
           return new[] {NewException(string.Format("{{0}}:{0}{1}", Environment.NewLine, errorMessage), nodeName)};
         }
 

--- a/Source/Machine.Specifications/Utility/Internal/PrettyPrintingExtensions.cs
+++ b/Source/Machine.Specifications/Utility/Internal/PrettyPrintingExtensions.cs
@@ -3,11 +3,15 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace Machine.Specifications.Utility.Internal
 {
   public static class PrettyPrintingExtensions
   {
+    private const string CurlyBraceSurround = "{{{0}}}";
+    private static readonly Regex EscapeNonFormatBraces = new Regex(@"{([^\d].*?)}", RegexOptions.Compiled | RegexOptions.Singleline);
+
     public static string FormatErrorMessage(object actualObject, object expectedObject)
     {
       if (actualObject == null || !(actualObject is string) ||
@@ -151,16 +155,16 @@ namespace Machine.Specifications.Utility.Internal
     {
       var sb = new StringBuilder();
       sb.AppendLine("{");
-      sb.Append(String.Join(",\n", enumerable.Select(x => x.ToUsefulString().Tab()).Take(10).ToArray()));
+      sb.Append(String.Join(",\r\n", enumerable.Select(x => x.ToUsefulString().Tab()).Take(10).ToArray()));
       if (enumerable.Count() > 10)
       {
         if (enumerable.Count() > 11)
         {
-          sb.AppendLine(String.Format(",\n  ...({0} more elements)", enumerable.Count() - 10));
+          sb.AppendLine(String.Format(",\r\n  ...({0} more elements)", enumerable.Count() - 10));
         }
         else
         {
-          sb.AppendLine(",\n" + enumerable.Last().ToUsefulString().Tab());
+          sb.AppendLine(",\r\n" + enumerable.Last().ToUsefulString().Tab());
         }
       }
       else
@@ -194,7 +198,7 @@ namespace Machine.Specifications.Utility.Internal
       {
         var enumerable = ((IEnumerable) obj).Cast<object>();
 
-        return obj.GetType() + ":\n" + enumerable.EachToUsefulString();
+        return obj.GetType() + ":\r\n" + enumerable.EachToUsefulString();
       }
 
       str = obj.ToString();
@@ -220,6 +224,11 @@ namespace Machine.Specifications.Utility.Internal
       }
 
       return string.Format("{0}:[{1}]", obj.GetType(), str);
+    }
+
+    internal static string EnsureSafeFormat(this string message)
+    {
+        return EscapeNonFormatBraces.Replace(message, match => string.Format(CurlyBraceSurround, match.Groups[0]));
     }
   }
 }


### PR DESCRIPTION
This small fix makes the ShouldBeLike more robust and allows the comparing of objects with collections as properties/fields.  No pre-existing functionality was altered or broken as a result of this pull request.
