### PR TITLE
Can now filter by test usages in find results

### DIFF
--- a/Source/Machine.Specifications.ReSharperRunner.6.0/MSpecUnitTestProvider.cs
+++ b/Source/Machine.Specifications.ReSharperRunner.6.0/MSpecUnitTestProvider.cs
@@ -119,6 +119,12 @@ namespace Machine.Specifications.ReSharperRunner
           return element is ContextSpecificationElement || element is BehaviorSpecificationElement;
         case UnitTestElementKind.TestContainer:
           return element is ContextElement || element is BehaviorElement;
+        case UnitTestElementKind.TestStuff:
+          return element is ContextSpecificationElement || element is BehaviorSpecificationElement ||
+                 element is ContextElement || element is BehaviorElement;
+        case UnitTestElementKind.Unknown:
+          return !(element is ContextSpecificationElement || element is BehaviorSpecificationElement ||
+                   element is ContextElement || element is BehaviorElement);
       }
 
       return false;
@@ -132,6 +138,10 @@ namespace Machine.Specifications.ReSharperRunner
           return declaredElement.IsSpecification();
         case UnitTestElementKind.TestContainer:
           return declaredElement.IsContext() || declaredElement.IsBehavior();
+        case UnitTestElementKind.TestStuff:
+          return declaredElement.IsSpecification() || declaredElement.IsContext() || declaredElement.IsBehavior();
+        case UnitTestElementKind.Unknown:
+          return !(declaredElement.IsSpecification() || declaredElement.IsContext() || declaredElement.IsBehavior());
       }
 
       return false;


### PR DESCRIPTION
In the example specs, try find usages on the Account class. With this change, you can now change the filter drop down in the Find Results window to uncheck "Show Unit Test Usages",  and it will remove the occurrences that are used in unit test objects. It will also show the test icon in the drop down lists when invoking Go to Type for e.g. BankingSpecs. Works with 6.1 and 7.1
