### PR TITLE
Convert subject attribute extraction to use System.ComponentModel

### DIFF
--- a/Source/Machine.Specifications.Example.Random/ExampleSpecs.cs
+++ b/Source/Machine.Specifications.Example.Random/ExampleSpecs.cs
@@ -109,6 +109,10 @@ namespace Machine.Specifications.Specs
     };
   }
 
+  public class context_without_subject
+  {
+  }
+
   [Subject(typeof(int), "Some description")]
   [Tags(tag.example)]
   public class context_with_subject

--- a/Source/Machine.Specifications.Specs/Factories/ContextFactorySpecs.cs
+++ b/Source/Machine.Specifications.Specs/Factories/ContextFactorySpecs.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.ComponentModel;
+using System.Linq;
 
 using Machine.Specifications.Factories;
 using Machine.Specifications.Model;
@@ -167,5 +168,41 @@ namespace Machine.Specifications.Specs.Factories
 
     It should_capture_the_tags_once =
       () => newContext.Tags.Count().ShouldEqual(1);
+  }
+
+  [Subject(typeof(ContextFactory))]
+  public class when_creating_a_context_with_a_concern_that_has_had_a_subject_attribute_added_dynamically
+  {
+    static Context newContext;
+
+    Establish context = () =>
+    {
+      TypeDescriptor.AddAttributes(typeof(context_without_subject), new SubjectAttribute(typeof(int), "holz"));
+      newContext = new ContextFactory().CreateContextFrom(new context_without_subject());
+    };
+
+    It should_capture_the_subject_type =
+      () => newContext.Subject.Type.ShouldEqual(typeof(int));
+
+    It should_capture_the_subject_description =
+      () => newContext.Subject.Description.ShouldEqual("holz");
+  }
+
+  [Subject(typeof(ContextFactory))]
+  public class when_creating_a_context_with_a_concern_with_a_subject_attribute_that_has_also_had_a_subject_attribute_added_dynamically
+  {
+    static Context newContext;
+
+    Establish context = () =>
+    {
+      TypeDescriptor.AddAttributes(typeof(context_with_subject), new SubjectAttribute(typeof(object), "holz"));
+      newContext = new ContextFactory().CreateContextFrom(new context_with_subject());
+    };
+
+    It should_use_the_dynamically_added_subject_type =
+      () => newContext.Subject.Type.ShouldEqual(typeof(object));
+
+    It should_use_the_dynamically_added_subject_description =
+      () => newContext.Subject.Description.ShouldEqual("holz");
   }
 }

--- a/Source/Machine.Specifications/Factories/ContextFactory.cs
+++ b/Source/Machine.Specifications/Factories/ContextFactory.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 
@@ -108,14 +109,14 @@ namespace Machine.Specifications.Factories
 
     static Subject ExtractSubject(Type type)
     {
-      var attributes = type.GetCustomAttributes(typeof(SubjectAttribute), true);
+      var attributes = TypeDescriptor.GetAttributes(type).OfType<SubjectAttribute>();
 
-      if (attributes.Length > 1)
+      if (attributes.Count() > 1)
       {
         throw new SpecificationUsageException("Cannot have more than one Subject on a Context");
       }
 
-      if (attributes.Length == 0)
+      if (!attributes.Any())
       {
         if (type.DeclaringType == null)
         {
@@ -125,9 +126,7 @@ namespace Machine.Specifications.Factories
         return ExtractSubject(type.DeclaringType);
       }
 
-      var attribute = (SubjectAttribute)attributes[0];
-
-      return attribute.CreateSubject();
+      return attributes.First().CreateSubject();
     }
 
     void CreateSpecifications(IEnumerable<FieldInfo> itFieldInfos, Context context)


### PR DESCRIPTION
I'm planning to add subject attributes dynamically from machine.fakes. This way no `SubjectAttribute` would have to be added in explicitly on specs that derive from `WithSubject<>`.

For this to work the attribute has to be added and extracted through System.ComponentModel instead of normal reflection.

I could not test this in the ReSharper runner, but it works all right in the console runner. As far as I could see the ReSharper runner uses the same logic to extract the subject?

I have not tested this for performance, but can do if you think this could be an issue.
