### PR TITLE
Add null value check on rawString to avoid NullReferenceException

### DIFF
--- a/Source/Machine.Specifications.Reporting/Integration/TeamCityServiceMessageWriter.cs
+++ b/Source/Machine.Specifications.Reporting/Integration/TeamCityServiceMessageWriter.cs
@@ -256,6 +256,8 @@ namespace Machine.Specifications.Reporting.Integration
 
         private static void AppendEscapedString(StringBuilder builder, string rawString)
         {
+          if (rawString == null)
+             return;
           foreach (char c in rawString)
           {
             switch (c)


### PR DESCRIPTION
See the bug listed here: http://youtrack.jetbrains.com/issue/TW-28434

Getting NullReferenceException on certain MSpec exceptions, I think because Message is null?
