### PR TITLE
Fixed context mapping

### DIFF
--- a/Source/Runners/Machine.Specifications.ReSharper.Utility/RunOptionsExtensions.cs
+++ b/Source/Runners/Machine.Specifications.ReSharper.Utility/RunOptionsExtensions.cs
@@ -34,7 +34,7 @@ namespace Machine.Specifications.Runner.Utility
 
         private static void AppendContexts(XElement root, RunOptions runOptions)
         {
-            AppendItems(root, runOptions.Filters, "contexts", "context");
+            AppendItems(root, runOptions.Contexts, "contexts", "context");
         }
 
         private static void AppendItems(XElement root, IEnumerable<string> items, string itemsElementName, string itemElementName)


### PR DESCRIPTION
To get rid of the empty stack trace exceptions by  fixing a small mistake in the RunOptions to XML mapper. 
