### PR TITLE
Fix #170: Fail on exception during cleanup

### DIFF
--- a/Source/Examples/Example.Random/ExampleSpecs.cs
+++ b/Source/Examples/Example.Random/ExampleSpecs.cs
@@ -197,6 +197,14 @@ namespace Example.Random
   }
 
   [Tags(tag.example)]
+  public class context_with_failing_cleanup
+  {
+    Because of = () => { };
+    It should = () => { };
+    Cleanup after = () => { throw new InvalidOperationException("something went wrong"); };
+  }
+
+  [Tags(tag.example)]
   public class context_with_console_output
   {
     Establish context =

--- a/Source/Machine.Specifications.Specs/Machine.Specifications.Specs.csproj
+++ b/Source/Machine.Specifications.Specs/Machine.Specifications.Specs.csproj
@@ -131,6 +131,7 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
@@ -141,8 +142,6 @@
   </PropertyGroup>
   <Target Name="AfterBuild">
     <MakeDir Directories="$(SpecsFolder)" />
-    <Exec 
-      Condition="'$(Configuration)' == 'Release'" 
-      Command="$(SolutionDir)\packages\Machine.Specifications.Runner.Console.0.9.0-Unstable0017\tools\mspec.exe --progress --silent $(TargetPath) --html $(SpecsFolder)$(MSBuildProjectName).html" />
-  </Target>  
+    <Exec Condition="'$(Configuration)' == 'Release'" Command="$(SolutionDir)\packages\Machine.Specifications.Runner.Console.0.9.0-Unstable0017\tools\mspec.exe --progress --silent $(TargetPath) --html $(SpecsFolder)$(MSBuildProjectName).html" />
+  </Target>
 </Project>

--- a/Source/Machine.Specifications.Specs/Machine.Specifications.Specs.csproj
+++ b/Source/Machine.Specifications.Specs/Machine.Specifications.Specs.csproj
@@ -142,6 +142,8 @@
   </PropertyGroup>
   <Target Name="AfterBuild">
     <MakeDir Directories="$(SpecsFolder)" />
-    <Exec Condition="'$(Configuration)' == 'Release'" Command="$(SolutionDir)\packages\Machine.Specifications.Runner.Console.0.9.0-Unstable0017\tools\mspec.exe --progress --silent $(TargetPath) --html $(SpecsFolder)$(MSBuildProjectName).html" />
-  </Target>
+    <Exec 
+      Condition="'$(Configuration)' == 'Release'" 
+      Command="$(SolutionDir)\packages\Machine.Specifications.Runner.Console.0.9.0-Unstable0017\tools\mspec.exe --progress --silent $(TargetPath) --html $(SpecsFolder)$(MSBuildProjectName).html" />
+  </Target>  
 </Project>

--- a/Source/Machine.Specifications.Specs/Runner/SpecificationRunnerSpecs.cs
+++ b/Source/Machine.Specifications.Specs/Runner/SpecificationRunnerSpecs.cs
@@ -183,6 +183,16 @@ namespace Machine.Specifications.Specs.Runner
   }
 
   [Subject("Specification Runner")]
+  public class when_running_a_context_with_failing_cleanup_clauses
+    : RunnerSpecs
+  {
+      Because of = Run<context_with_failing_cleanup>;
+
+      It should_fail = () =>
+      testListener.LastResult.Passed.Should().BeFalse();
+  }
+
+  [Subject("Specification Runner")]
   public class when_running_a_context_with_failing_because_clauses
     : RunnerSpecs
   {

--- a/Source/Machine.Specifications.Specs/app.config
+++ b/Source/Machine.Specifications.Specs/app.config
@@ -1,0 +1,5 @@
+﻿<configuration>
+  <startup>
+    <supportedRuntime version="v2.0.50727"/>
+  </startup>
+</configuration>

--- a/Source/Machine.Specifications.Tests/Machine.Specifications.Tests.csproj
+++ b/Source/Machine.Specifications.Tests/Machine.Specifications.Tests.csproj
@@ -112,6 +112,7 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/Machine.Specifications.Tests/app.config
+++ b/Source/Machine.Specifications.Tests/app.config
@@ -1,0 +1,5 @@
+﻿<configuration>
+  <startup>
+    <supportedRuntime version="v2.0.50727"/>
+  </startup>
+</configuration>

--- a/Source/Machine.Specifications/Runner/Impl/ContextRunner.cs
+++ b/Source/Machine.Specifications/Runner/Impl/ContextRunner.cs
@@ -34,7 +34,12 @@ namespace Machine.Specifications.Runner.Impl
 
       if (context.HasExecutableSpecifications)
       {
-        result = context.Cleanup();
+        var cleanupResult = context.Cleanup();
+        if (!cleanupResult.Passed)
+        {
+            results = FailSpecifications(context, listener, options, cleanupResult, resultSupplementers);
+        }
+        
         foreach (var cleanup in globalCleanups)
         {
           cleanup.AfterContextCleanup();

--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -7,9 +7,6 @@
   <repository path="..\Source\Examples\Example.CustomDelegates\packages.config" />
   <repository path="..\Source\Examples\Example.DerivedSubject\packages.config" />
   <repository path="..\Source\Examples\Example.Failing\packages.config" />
-  <repository path="..\Source\Examples\Example.Issue146-NoMSpecDll\packages.config" />
-  <repository path="..\Source\Examples\Example.Issue157-Fail\packages.config" />
-  <repository path="..\Source\Examples\Example.Issue157-Success\packages.config" />
   <repository path="..\Source\Examples\Example.Random\packages.config" />
   <repository path="..\Source\Examples\Example.UsingExternalFile\packages.config" />
   <repository path="..\Source\Examples\Example.WithBehavior\packages.config" />


### PR DESCRIPTION
This change has the following effects:
- spec test fails when `Cleanup` delegate throws an exception. Same as with `Because` delegate.
- will hide (swallow) errors which occurred during running of `Because` and `It`

Caution: The results for a spec test are reported twice:
    
    listener.OnSpecificationStart
    listener.OnSpecificationEnd

are run twice per `SpecificationInfo`. With different `Result`s.

It seems to "work" in resharper runner, but i highly suspect you're going to tell me it's invalid and that by design each specification can only start and end once ;-)

If that's the case i want to present a few options:

 - reporting to the listener can be delayed until cleanup is run.
   - That means it's not live anymore. you won't see if an `it` is hanging the build/runner.
   - There's still the issue with, well, basically `AggregateException`: More than one failure results may have accumalted when `Cleanup` was run: either `Because` or the `It` may have failed: How to report them without losing information?
 - Instead of reporting an `It` failure one could report a fatal error when a `Cleanup` fails. 
   - Also do the same for `Because`?
   - would make sure there's not unintended effects on further run spec tests.
 - Implement a new option to report the failure of a `When` separate from it's `Its.
   - that would reflect that while all `It`s may have passed the test as a whole may still have failed

If that's the case the option is to delay reporting of results until cleanup has run (it's not perfectly live then anymore) - but this still has the problem of 