### PR TITLE
Fix #170: Exception thrown by Cleanup delegate now fails the test runner.

### DIFF
--- a/Source/Examples/Example.Random/ExampleSpecs.cs
+++ b/Source/Examples/Example.Random/ExampleSpecs.cs
@@ -197,6 +197,15 @@ namespace Example.Random
   }
 
   [Tags(tag.example)]
+  public class context_with_failing_cleanup
+  {
+    public static readonly Exception ExceptionThrownByCleanup = new InvalidOperationException("something went wrong");
+
+    It should = () => { };
+    Cleanup after = () => { throw ExceptionThrownByCleanup; };
+  }
+
+  [Tags(tag.example)]
   public class context_with_console_output
   {
     Establish context =

--- a/Source/Machine.Specifications.Specs/App.config
+++ b/Source/Machine.Specifications.Specs/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <startup>
+    <supportedRuntime version="v2.0.50727"/>
+  </startup>
+</configuration>

--- a/Source/Machine.Specifications.Specs/Machine.Specifications.Specs.csproj
+++ b/Source/Machine.Specifications.Specs/Machine.Specifications.Specs.csproj
@@ -131,6 +131,7 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
+    <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Source/Machine.Specifications.Specs/Runner/SpecificationRunnerSpecs.cs
+++ b/Source/Machine.Specifications.Specs/Runner/SpecificationRunnerSpecs.cs
@@ -179,7 +179,7 @@ namespace Machine.Specifications.Specs.Runner
     Because of = Run<context_with_failing_establish>;
 
     It should_fail = () =>
-    testListener.LastResult.Passed.Should().BeFalse();
+      testListener.LastResult.Passed.Should().BeFalse();
   }
 
   [Subject("Specification Runner")]
@@ -189,7 +189,22 @@ namespace Machine.Specifications.Specs.Runner
     Because of = Run<context_with_failing_because>;
 
     It should_fail = () =>
-    testListener.LastResult.Passed.Should().BeFalse();
+      testListener.LastResult.Passed.Should().BeFalse();
+  }
+
+  [Subject("Specification Runner")]
+  public class when_running_a_context_with_failing_cleanup_clause
+    : RunnerSpecs
+  {
+    static Exception exception;
+
+    Because of = Run<context_with_failing_cleanup>;
+      
+    It should_report_cleanup_exception = () => 
+      testListener
+        .LastFatalError
+        .InnerExceptionResult
+        .Message.Should().Be(context_with_failing_cleanup.ExceptionThrownByCleanup.Message);
   }
 
   [Subject("Specification Runner")]

--- a/Source/Machine.Specifications.Tests/App.config
+++ b/Source/Machine.Specifications.Tests/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <startup>
+    <supportedRuntime version="v2.0.50727"/>
+  </startup>
+</configuration>

--- a/Source/Machine.Specifications.Tests/Machine.Specifications.Tests.csproj
+++ b/Source/Machine.Specifications.Tests/Machine.Specifications.Tests.csproj
@@ -112,6 +112,7 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
+    <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/Machine.Specifications/Runner/Impl/ContextRunner.cs
+++ b/Source/Machine.Specifications/Runner/Impl/ContextRunner.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using Machine.Specifications.Model;
 using System.Linq;
@@ -34,7 +33,12 @@ namespace Machine.Specifications.Runner.Impl
 
       if (context.HasExecutableSpecifications)
       {
-        result = context.Cleanup();
+        var cleanupResult = context.Cleanup();
+        if (!cleanupResult.Passed)
+        {
+          listener.OnFatalError(cleanupResult.Exception);
+        }
+
         foreach (var cleanup in globalCleanups)
         {
           cleanup.AfterContextCleanup();

--- a/history.txt
+++ b/history.txt
@@ -1,3 +1,7 @@
+Machine.Specifications 0.9.2
+-----------------------------
+- Fixed #170: runner aborts and test fails in case a Cleanup delegate throws an exception.
+
 Machine.Specifications 0.9.1
 -----------------------------
 - Fixed #255 to re-enable capture output feature.


### PR DESCRIPTION
An exception thrown by a `Cleanup` delegate now fails the test runner. In R# runner, this means a modal dialog box which says `FooException` occurs. Expanding the dialog will show the exact stack trace.

This replaces pull request #264 and fixes #170.

What i have done is:
 - create an example spec with failing `Cleanup` delegate
 - create a spec test for the new / changed behavior
 - changed `ContextRunner` to do `listener.OnFatalError(cleanupResult.Exception)` in case cleanup did not pass.
 - Added App.config to test projects to prevent BadImageFormatException when accessing FluentAssertions (it's trying to load the wrong assembly (version))
 - Added change to history.txt