### PR TITLE
Replace Assembly.LoadFile() calls with LoadFrom() in DefaultRunner

### DIFF
--- a/Source/Machine.Specifications/Runner/Impl/DefaultRunner.cs
+++ b/Source/Machine.Specifications/Runner/Impl/DefaultRunner.cs
@@ -174,28 +174,28 @@ namespace Machine.Specifications.Runner.Impl
             {
                 // TODO: Optimize loading of assemblies
                 case "startrun":
-                    this.StartRun(Assembly.LoadFile(element.Value));
+                    this.StartRun(Assembly.LoadFrom(element.Value));
                     break;
                 case "endrun":
-                    this.EndRun(Assembly.LoadFile(element.Value));
+                    this.EndRun(Assembly.LoadFrom(element.Value));
                     break;
                 case "runassembly":
-                    this.RunAssembly(Assembly.LoadFile(element.Value));
+                    this.RunAssembly(Assembly.LoadFrom(element.Value));
                     break;
                 case "runnamespace":
                     assemblyElement = element.XPathSelectElement("/runner/runnamespace/assembly");
                     var namespaceElement = element.XPathSelectElement("/runner/runnamespace/namespace");
 
-                    this.RunNamespace(Assembly.LoadFile(assemblyElement.Value), namespaceElement.Value);
+                    this.RunNamespace(Assembly.LoadFrom(assemblyElement.Value), namespaceElement.Value);
                     break;
                 case "runmember":
                     assemblyElement = element.XPathSelectElement("/runner/runmember/assembly");
                     var memberInfo = msg.Properties["member"] as MemberInfo;
 
-                    this.RunMember(Assembly.LoadFile(assemblyElement.Value), memberInfo);
+                    this.RunMember(Assembly.LoadFrom(assemblyElement.Value), memberInfo);
                     break;
                 case "runassemblies":
-                    this.RunAssemblies(element.Elements("assemblies").Select(e => Assembly.LoadFile(e.Value)));
+                    this.RunAssemblies(element.Elements("assemblies").Select(e => Assembly.LoadFrom(e.Value)));
                     break;
             }
 

--- a/Source/Machine.Specifications/Sdk/RunSpecs.cs
+++ b/Source/Machine.Specifications/Sdk/RunSpecs.cs
@@ -9,7 +9,7 @@ namespace Machine.Specifications.Sdk
         public RunSpecs(object listener, string runOptionsXml, IEnumerable<string> assemblyPaths)
             : base(listener, runOptionsXml)
         {
-            var assemblies = assemblyPaths.Select(Assembly.LoadFile);
+            var assemblies = assemblyPaths.Select(Assembly.LoadFrom);
 
             // TODO: What to do with that?
             if (RunOptions.Contexts.Any())


### PR DESCRIPTION
Fixes #278.

LoadFrom() uses "Fusion" to resolve the assembly (which will be shadow copied if it is within the base directory and shadow copying is enabled). Currently, the LoadFile() calls don't shadow copy the test assembly in SyncProcessMessage() which leads to a second load of the test assembly within `AssemblyContextRunListener.OnAssemblyStart()` as described in #278.

@ contributors: 
* Was there a special reason to choose LoadFile() over LoadFrom()?
* There is another LoadFile() call in `Machine.Specifications.Sdk.RunSpecs`. Should this also be adapted?