### PR TITLE
Fix for performance issues in Visual Studio/MSTest adapter (possibly also DNX one)

### DIFF
--- a/Source/Machine.Specifications/Model/Specification.cs
+++ b/Source/Machine.Specifications/Model/Specification.cs
@@ -11,7 +11,7 @@ namespace Machine.Specifications.Model
     {
         readonly string _name;
         readonly Delegate _it;
-        readonly bool _isIgnored;
+        bool _isIgnored;
         readonly FieldInfo _fieldInfo;
         readonly string _leader;
 
@@ -28,6 +28,7 @@ namespace Machine.Specifications.Model
         public bool IsIgnored
         {
             get { return _isIgnored; }
+            set { _isIgnored = value; }
         }
 
         public string Leader

--- a/Source/Machine.Specifications/Runner/Impl/DefaultRunner.cs
+++ b/Source/Machine.Specifications/Runner/Impl/DefaultRunner.cs
@@ -223,6 +223,22 @@ namespace Machine.Specifications.Runner.Impl
                 results = results.Where(x => includeFilters.Any(filter => StringComparer.OrdinalIgnoreCase.Equals(filter, x.Type.FullName)));
             }
 
+            if (options.Specifications.Any())
+            {
+                var includeSpecs = options.Specifications;
+
+                Func<Context, Specification,string> format = (context, spec) => {
+                    return String.Format("{0}::{1}::{2}", context.Type.Assembly.GetName().Name, context.Type.FullName, spec.FieldInfo.Name);
+                };
+
+                foreach (Context context in contexts) {
+                    context.Specifications
+                        .Where(spec => !includeSpecs.Any(includedSpec => includedSpec.Equals(format(context, spec), StringComparison.OrdinalIgnoreCase)))
+                        .ToList()
+                        .ForEach(spec => spec.IsIgnored = true);
+                }
+            }
+
             if (options.IncludeTags.Any())
             {
                 var tags = options.IncludeTags.Select(tag => new Tag(tag));

--- a/Source/Machine.Specifications/Runner/RunOptions.cs
+++ b/Source/Machine.Specifications/Runner/RunOptions.cs
@@ -13,6 +13,7 @@ namespace Machine.Specifications.Runner
         public IEnumerable<string> ExcludeTags { get; private set; }
         public IEnumerable<string> Filters { get; private set; }
         public IEnumerable<string> Contexts { get; private set; }
+        public IEnumerable<string> Specifications { get; private set; }
 
         public RunOptions(IEnumerable<string> includeTags, IEnumerable<string> excludeTags, IEnumerable<string> filters)
             : this(includeTags, excludeTags, filters, Enumerable.Empty<string>())
@@ -20,11 +21,16 @@ namespace Machine.Specifications.Runner
         }
 
         public RunOptions(IEnumerable<string> includeTags, IEnumerable<string> excludeTags, IEnumerable<string> filters, IEnumerable<string> contexts)
+            : this(includeTags, excludeTags, filters, contexts, Enumerable.Empty<string>())
+        {
+        }
+        public RunOptions(IEnumerable<string> includeTags, IEnumerable<string> excludeTags, IEnumerable<string> filters, IEnumerable<string> contexts, IEnumerable<string> specifications)
         {
             IncludeTags = includeTags;
             ExcludeTags = excludeTags;
             Filters = filters;
             Contexts = contexts;
+            Specifications = specifications;
         }
 
         public static RunOptions Default { get { return new RunOptions(Enumerable.Empty<string>(), Enumerable.Empty<string>(), Enumerable.Empty<string>(), Enumerable.Empty<string>()); } }
@@ -37,8 +43,9 @@ namespace Machine.Specifications.Runner
             IEnumerable<string> excludeTags = Parse(document, "/runoptions/excludetags/tag");
             IEnumerable<string> filters = Parse(document, "/runoptions/filters/filter");
             IEnumerable<string> contexts = Parse(document, "/runoptions/contexts/context");
+            IEnumerable<string> specifications = Parse(document, "/runoptions/contexts/specifications");
 
-            return new RunOptions(includeTags, excludeTags, filters, contexts);
+            return new RunOptions(includeTags, excludeTags, filters, contexts, specifications);
         }
 
         private static IEnumerable<string> Parse(XDocument document, string xpath)


### PR DESCRIPTION
Consider this test class:

```csharp

public class When_something
{
    Establish context;
    Because of;
    It should_do_x;
    It should_do_y;
    Cleanup cleanup;
}
```

When this is ran normally through the current MSpec pipeline using Mspec itself pointed at an assembly .dll - it will use `DefaultRunner.RunAssembly(Assembly)`. Internally MSpec will create a `Context` (using `ContextFactory`) and unless the `SetupForEachSpecification` attribute is used on the type it will use a `SetupForEachContextRunner` and thus the execution flow will be as per below:

1. Run `Establish`
2. Run `Because`
3. Run `should_do_x`
4. Run `should_do_y`
5. Run `Cleanup`

In the Visual Studio Test adapter stuff though what Visual Studio tells us is something like the below input:

```json
[
  {
    "Assembly": "path\\to\\My.Tests.dll",
    "Tests": [
      "When_something::should_do_x",
      "When_something::should_do_y"
    ]
  },
  {
    /* another assembly */
  }
]
```

And the lists of `Tests` can be artibtrary: all `It` in an assembly, only a subset based on the user selection (see screenshot). So we end up using `DefaultRunner.RunMember` in a loop, which means that internally we end up with a `Context` for each `It` and Establish/Because/Cleanup get run for each `It` too:

1.  `DefaultRunner.RunMember(should_do_x)`
2. Run `Establish`
3. Run `Because`
4. Run `should_do_x`
5. Run `Cleanup`
6.  `DefaultRunner.RunMember(should_do_y)`
7. Run `Establish`
8. Run `Because`
9. Run `should_do_y`
10. Run `Cleanup`

My challenge here is that given a list of `It` I want to run the tests efficiently and I have identified two approaches:

1. Use filtering (as per this pull request) to say "I want you to run only those `It`" and use the existing MSpec test execution pipeline
2. Build my own `ISpecificationRunner` outside of MSpec, however:
 * `ContextFactory.CreateContextFrom(object instance, IEnumerable<FieldInfo> acceptedSpecificationFields)` is not public either
 * `AssemblyRunner` to run the produced `Context` is not public either
 *  I will have to duplicate some code from `DefaultRunner` and am risking in the future to diverge behaviourally from core Mspec

I am happy with either.

![image](https://cloud.githubusercontent.com/assets/79742/13249004/9f55e1bc-da19-11e5-8696-c82340af2442.png)