### PR TITLE
[Feature] Track behavior field from context in behavior spec

### DIFF
--- a/Source/Machine.Specifications.Specs/Factories/ContextFactorySpecs.cs
+++ b/Source/Machine.Specifications.Specs/Factories/ContextFactorySpecs.cs
@@ -236,4 +236,23 @@ namespace Machine.Specifications.Specs.Factories
       }
     }
   }
+
+  [Subject(typeof(ContextFactory))]
+  public class when_creating_behavior_specifications_and_tracking_original_behavior_field
+  {
+    static Context newContext;
+
+    Establish context = () =>
+    {
+      var factory = new ContextFactory();
+      newContext = factory.CreateContextFrom(new context_with_behaviors());
+    };
+
+    It should_create_behavior_specs_with_original_behavior_field =
+      () => newContext.Specifications
+        .OfType<BehaviorSpecification>()
+        .First()
+        .BehaviorFieldInfo.Name.Should().BeEquivalentTo("behavior");
+
+  }
 }

--- a/Source/Machine.Specifications/Factories/BehaviorFactory.cs
+++ b/Source/Machine.Specifications/Factories/BehaviorFactory.cs
@@ -34,7 +34,7 @@ namespace Machine.Specifications.Factories
             var behavior = new Behavior(behaviorField.FieldType, behaviorInstance, context, isIgnored);
 
             var itFieldInfos = behaviorType.GetInstanceFieldsOfUsage(new AssertDelegateAttributeFullName());
-            CreateBehaviorSpecifications(itFieldInfos, behavior);
+            CreateBehaviorSpecifications(itFieldInfos, behaviorField, behavior);
 
             return behavior;
         }
@@ -126,11 +126,13 @@ namespace Machine.Specifications.Factories
         }
 
         void CreateBehaviorSpecifications(IEnumerable<FieldInfo> itFieldInfos,
+                                          FieldInfo behaviorField,
                                           Behavior behavior)
         {
             foreach (var itFieldInfo in itFieldInfos)
             {
                 var specification = _specificationFactory.CreateSpecificationFromBehavior(behavior,
+                                                                                          behaviorField,
                                                                                           itFieldInfo);
                 behavior.AddSpecification(specification);
             }

--- a/Source/Machine.Specifications/Factories/SpecificationFactory.cs
+++ b/Source/Machine.Specifications/Factories/SpecificationFactory.cs
@@ -19,13 +19,13 @@ namespace Machine.Specifications.Factories
             return new Specification(name, specificationField.FieldType, it, isIgnored, specificationField);
         }
 
-        public Specification CreateSpecificationFromBehavior(Behavior behavior, FieldInfo specificationField)
+        public Specification CreateSpecificationFromBehavior(Behavior behavior, FieldInfo behaviorField, FieldInfo specificationField)
         {
             bool isIgnored = behavior.IsIgnored || specificationField.HasAttribute(new IgnoreAttributeFullName());
             var it = (Delegate)specificationField.GetValue(behavior.Instance);
             string name = specificationField.Name.ToFormat();
 
-            return new BehaviorSpecification(name, specificationField.FieldType, it, isIgnored, specificationField, behavior.Context, behavior);
+            return new BehaviorSpecification(name, specificationField.FieldType, behaviorField, it, isIgnored, specificationField, behavior.Context, behavior);
         }
     }
 }

--- a/Source/Machine.Specifications/Model/BehaviorSpecification.cs
+++ b/Source/Machine.Specifications/Model/BehaviorSpecification.cs
@@ -8,12 +8,14 @@ namespace Machine.Specifications.Model
 {
     public class BehaviorSpecification : Specification
     {
+        readonly FieldInfo _behaviorfield;
         readonly object _behaviorInstance;
         readonly object _contextInstance;
         readonly ConventionMapper _mapper;
 
         public BehaviorSpecification(string name,
                                      Type fieldType,
+                                     FieldInfo behaviorfield,
                                      Delegate it,
                                      bool isIgnored,
                                      FieldInfo fieldInfo,
@@ -21,10 +23,16 @@ namespace Machine.Specifications.Model
                                      Behavior behavior)
             : base(name, fieldType, it, isIgnored, fieldInfo)
         {
+            _behaviorfield = behaviorfield;
             _contextInstance = context.Instance;
             _behaviorInstance = behavior.Instance;
 
             _mapper = new ConventionMapper();
+        }
+
+        public FieldInfo BehaviorFieldInfo
+        {
+            get { return _behaviorfield; }
         }
 
         protected override void InvokeSpecificationField()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
-  nuget_version: '0.11.2'
+  nuget_version: '0.12.0'
   nuget_prerelease: false
-  assembly_version: '0.11.2.0'
+  assembly_version: '0.12.0.0'
 
 image: Visual Studio 2017
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,14 @@
 environment:
-  nuget_version: '0.11.1'
+  nuget_version: '0.11.2'
   nuget_prerelease: false
-  assembly_version: '0.11.0.0'
+  assembly_version: '0.11.2.0'
 
 image: Visual Studio 2017
 
 deploy:
   - provider: GitHub
     description: |
-      * Fix ArgumentOutOfRangeException thrown when tests are concurrently writing diagnostic output. (#224 - thanks to dannyvincent)
+      * Track behavior field from context in behavior specification
 
     on:
       appveyor_repo_tag: true


### PR DESCRIPTION
This is needed for dotnet core support in the ReSharper provider, here: https://github.com/machine/machine.specifications.runner.resharper/issues/46.

A change will also be needed to the VS runner to pass through this data to the test runner, probably as a `Trait`, which will then be picked up by ReSharper and passed to the provider.

The reason we need this in the ReSharper provider is that we need to know the name of the context field that is using the behavior specs.

Tagging @ivanz 