### PR TITLE
Add test case filter to RunOptions (Support for #327)

### DIFF
--- a/Source/Examples/Example/FailingSpecs.cs
+++ b/Source/Examples/Example/FailingSpecs.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Machine.Specifications;
+
+namespace Example
+{
+    [Subject("example")]
+    public class when_context_with_passing_and_failing_clauses
+    {
+        It should_fail = () => throw new Exception();
+
+        It should_pass = () => { };
+    }
+}

--- a/Source/Machine.Specifications.Specs/Runner/SpecificationRunnerRunAssemblyWithFilterSpecs.cs
+++ b/Source/Machine.Specifications.Specs/Runner/SpecificationRunnerRunAssemblyWithFilterSpecs.cs
@@ -1,0 +1,61 @@
+﻿
+using System.Linq;
+using System.Reflection;
+
+using Example;
+
+using FluentAssertions;
+using Machine.Specifications.Runner;
+using Machine.Specifications.Runner.Impl;
+
+namespace Machine.Specifications.Specs.Runner
+{
+    [Subject("Specification Runner")]
+    public class when_running_a_context_while_filtering_out_failing_tests
+    {
+        static TestListener testListener;
+    
+        static DefaultRunner runner;
+
+        Establish context = () =>
+        {
+            testListener = new TestListener();
+            var filters = new[]
+                          {
+                              new ContextFilter(
+                                  "Example.when_context_with_passing_and_failing_clauses",
+                                  new[]
+                                  {
+                                      new SpecifiactionFilter("should_pass"),
+                                  })
+                          };
+            var runOptions = new RunOptions(
+                Enumerable.Empty<string>(),
+                Enumerable.Empty<string>(),
+                filters);
+
+            runner = new DefaultRunner(
+                testListener,
+                runOptions);
+        };
+
+        Because of =
+            () => runner.RunAssemblyContainingType<when_context_with_passing_and_failing_clauses>();
+        
+        It should_succeed =
+            () => testListener.LastResult.Passed.Should().BeTrue();
+    
+        It should_run_spec =
+            () => testListener.SpecCount.Should().Be(1);
+    }
+
+    public static class RunnerExtensions
+    {
+        public static void RunAssemblyContainingType<T>(
+            this DefaultRunner runner)
+            where T : new()
+        {
+            runner.RunAssembly(typeof(T).GetTypeInfo().Assembly);
+        }
+    }
+}

--- a/Source/Machine.Specifications.Tests/Explorers/AssemblyExplorerTests.cs
+++ b/Source/Machine.Specifications.Tests/Explorers/AssemblyExplorerTests.cs
@@ -22,18 +22,19 @@ namespace Machine.Specifications.Explorers
     }
 
     [Test]
-    public void ShouldReturnThreeContexts()
+    public void ShouldReturnFourContexts()
     {
-      specifications.Count().Should().Be(3);
+      specifications.Count().Should().Be(4);
     }
 
     [Test]
-    public void ShouldReturnThreeContextsNamedCorrectly()
+    public void ShouldReturnFourContextsNamedCorrectly()
     {
       var names = specifications.Select(x => x.Name).OrderBy(x => x).ToList();
       names.Should().BeEquivalentTo(
         new[]
     {
+      "when context with passing and failing clauses",
       "when a customer first views the account summary page",
       "when transferring between two accounts",
       "when transferring an amount larger than the balance of the from account"

--- a/Source/Machine.Specifications/Runner/ContextFilter.cs
+++ b/Source/Machine.Specifications/Runner/ContextFilter.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Machine.Specifications.Runner
+{
+#if !NETSTANDARD
+    [Serializable]
+#endif
+    public class ContextFilter
+    {
+        public ContextFilter(string name, IEnumerable<SpecifiactionFilter> specificFilters)
+        {
+            Name = name;
+            SpecificationFilters = specificFilters.ToList();
+        }
+
+        public string Name { get; }
+
+        public IEnumerable<SpecifiactionFilter> SpecificationFilters { get; }
+    }
+}

--- a/Source/Machine.Specifications/Runner/Impl/DefaultRunner.cs
+++ b/Source/Machine.Specifications/Runner/Impl/DefaultRunner.cs
@@ -246,9 +246,37 @@ namespace Machine.Specifications.Runner.Impl
 
             if (options.Filters.Any())
             {
-                var includeFilters = options.Filters;
+                var includeFilters = options.Filters.ToList();
 
-                results = results.Where(x => includeFilters.Any(filter => StringComparer.OrdinalIgnoreCase.Equals(filter, x.Type.FullName)));
+                results = results.Where(
+                    x => includeFilters.Any(
+                        filter => StringComparer.OrdinalIgnoreCase.Equals(
+                            filter.Name,
+                            x.Type.FullName)))
+                                 .ToList();
+
+                foreach (var context in results)
+                {
+                    ContextFilter contextFilter = includeFilters.Single(
+                        x => StringComparer.OrdinalIgnoreCase.Equals(
+                            x.Name,
+                            context.Type.FullName));
+                    List<SpecifiactionFilter> specifiactionFilters = contextFilter.SpecificationFilters.ToList();
+                    if (!specifiactionFilters.Any())
+                    {
+                        continue;
+                    }
+
+                    var specsToRun = context.Specifications
+                                            .Where(
+                                                s => specifiactionFilters.Any(
+                                                    sf => StringComparer.OrdinalIgnoreCase.Equals(
+                                                        sf.Name, 
+                                                        s.FieldInfo.Name)));
+                    context.Filter(specsToRun);
+                }
+
+                results = results.Where(x => x.Specifications.Any());
             }
 
             if (options.IncludeTags.Any())

--- a/Source/Machine.Specifications/Runner/RunOptions.cs
+++ b/Source/Machine.Specifications/Runner/RunOptions.cs
@@ -13,7 +13,7 @@ namespace Machine.Specifications.Runner
     {
         public IEnumerable<string> IncludeTags { get; private set; }
         public IEnumerable<string> ExcludeTags { get; private set; }
-        public IEnumerable<string> Filters { get; private set; }
+        public IEnumerable<ContextFilter> Filters { get; private set; }
         public IEnumerable<string> Contexts { get; private set; }
 
         public RunOptions(IEnumerable<string> includeTags, IEnumerable<string> excludeTags, IEnumerable<string> filters)
@@ -21,7 +21,17 @@ namespace Machine.Specifications.Runner
         {
         }
 
+        public RunOptions(IEnumerable<string> includeTags, IEnumerable<string> excludeTags, IEnumerable<ContextFilter> filters)
+            : this(includeTags, excludeTags, filters, Enumerable.Empty<string>())
+        {
+        }
+
         public RunOptions(IEnumerable<string> includeTags, IEnumerable<string> excludeTags, IEnumerable<string> filters, IEnumerable<string> contexts)
+            : this(includeTags, excludeTags, filters.Select(x => new ContextFilter(x, new SpecifiactionFilter[0])), contexts)
+        {
+        }
+
+        public RunOptions(IEnumerable<string> includeTags, IEnumerable<string> excludeTags, IEnumerable<ContextFilter> filters, IEnumerable<string> contexts)
         {
             IncludeTags = includeTags;
             ExcludeTags = excludeTags;
@@ -29,7 +39,7 @@ namespace Machine.Specifications.Runner
             Contexts = contexts;
         }
 
-        public static RunOptions Default { get { return new RunOptions(Enumerable.Empty<string>(), Enumerable.Empty<string>(), Enumerable.Empty<string>(), Enumerable.Empty<string>()); } }
+        public static RunOptions Default { get { return new RunOptions(Enumerable.Empty<string>(), Enumerable.Empty<string>(), Enumerable.Empty<ContextFilter>(), Enumerable.Empty<string>()); } }
 
         public static RunOptions Parse(string runOptionsXml)
         {
@@ -39,7 +49,7 @@ namespace Machine.Specifications.Runner
 
             IEnumerable<string> includeTags = Parse(document, "/runoptions/includetags/tag");
             IEnumerable<string> excludeTags = Parse(document, "/runoptions/excludetags/tag");
-            IEnumerable<string> filters = Parse(document, "/runoptions/filters/filter");
+            IEnumerable<ContextFilter> filters = Parse(document, "/runoptions/filters/filter").Select(x => new ContextFilter(x, Enumerable.Empty<SpecifiactionFilter>()));
             IEnumerable<string> contexts = Parse(document, "/runoptions/contexts/context");
 
             return new RunOptions(includeTags, excludeTags, filters, contexts);

--- a/Source/Machine.Specifications/Runner/SpecifiactionFilter.cs
+++ b/Source/Machine.Specifications/Runner/SpecifiactionFilter.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Machine.Specifications.Runner
+{
+#if !NETSTANDARD
+    [Serializable]
+#endif
+    public class SpecifiactionFilter
+    {
+        public SpecifiactionFilter(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; }
+    }
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,14 @@
 environment:
-  nuget_version: '0.12.0'
+  nuget_version: '0.13.0'
   nuget_prerelease: false
-  assembly_version: '0.12.0.0'
+  assembly_version: '0.13.0.0'
 
 image: Visual Studio 2017
 
 deploy:
   - provider: GitHub
     description: |
-      * Track behavior field from context in behavior specification
+      * Add filtering for test cases to RunOptions
 
     on:
       appveyor_repo_tag: true


### PR DESCRIPTION
Add constructor overloads to RunOptions to take a ContextFilter instead of a string. ContextFilters class consists of a name property and a set of SpecificationFilters. A SpecificationFilter contain just a name property. ContextFilters without any SpecificationFilters will behave the same as the current string filters. When any SpecificationFilters exist only the specifications with a matching name in that context will be run.