### PR TITLE
Feature/async support

### DIFF
--- a/src/Examples/Example.Random/ExampleSpecificationsUsedByNUnitTests.cs
+++ b/src/Examples/Example.Random/ExampleSpecificationsUsedByNUnitTests.cs
@@ -274,7 +274,52 @@ namespace Machine.Specifications
   }
 
   [Behaviors]
-  public class AsyncBehavior
+  public class ContextBehavior
+  {
+      protected static bool ItInvoked;
+
+      It is_a_specification = () =>
+      {
+          ItInvoked = true;
+      };
+  }
+
+  public class ContextWithBehavior : IFakeContext
+  {
+      public static bool BecauseInvoked = false;
+      protected static bool ItInvoked = false;
+      public static bool ItWasInvoked => ItInvoked;
+      public static bool ContextInvoked = false;
+      public static bool CleanupInvoked = false;
+
+      Establish context = () =>
+      {
+          ContextInvoked = true;
+      };
+
+      Because of = () =>
+      {
+          BecauseInvoked = true;
+      };
+
+      Behaves_like<ContextBehavior> behavior;
+
+      Cleanup after = () =>
+      {
+          CleanupInvoked = true;
+      };
+
+      public void Reset()
+      {
+          BecauseInvoked = false;
+          ItInvoked = false;
+          ContextInvoked = false;
+          CleanupInvoked = false;
+      }
+  }
+
+  [Behaviors]
+  public class AsyncContextBehavior
   {
       protected static bool ItInvoked;
 
@@ -314,7 +359,7 @@ namespace Machine.Specifications
           });
       };
 
-      Behaves_like<AsyncBehavior> behavior;
+      Behaves_like<AsyncContextBehavior> behavior;
 
       CleanupAsync after = async () =>
       {

--- a/src/Examples/Example.Random/ExampleSpecificationsUsedByNUnitTests.cs
+++ b/src/Examples/Example.Random/ExampleSpecificationsUsedByNUnitTests.cs
@@ -4,7 +4,9 @@ using FluentAssertions;
 
 namespace Machine.Specifications
 {
-  namespace ExampleA
+    using System.Threading.Tasks;
+
+    namespace ExampleA
   {
     namespace ExampleB
     {
@@ -217,5 +219,118 @@ namespace Machine.Specifications
       ContextInvoked = false;
       CleanupInvoked = false;
     }
+  }
+
+  public class AsyncContextWithSingleSpecification : IFakeContext
+  {
+      public static bool BecauseInvoked = false;
+      public static bool ItInvoked = false;
+      public static bool ContextInvoked = false;
+      public static bool CleanupInvoked = false;
+
+      EstablishAsync context = async () =>
+      {
+          await Task.Run(() =>
+          {
+              Task.Delay(10000);
+              ContextInvoked = true;
+          });
+      };
+
+      BecauseAsync of = async () =>
+      {
+          await Task.Run(() =>
+          {
+              Task.Delay(10000);
+              BecauseInvoked = true;
+          });
+      };
+
+      ItAsync is_a_specification = async () =>
+      {
+          await Task.Run(() =>
+          {
+              Task.Delay(10000);
+              ItInvoked = true;
+          });
+      };
+
+      CleanupAsync after = async () =>
+      {
+          await Task.Run(() =>
+          {
+              Task.Delay(10000);
+              CleanupInvoked = true;
+          });
+      };
+
+      public void Reset()
+      {
+          BecauseInvoked = false;
+          ItInvoked = false;
+          ContextInvoked = false;
+          CleanupInvoked = false;
+      }
+  }
+
+  [Behaviors]
+  public class AsyncBehavior
+  {
+      protected static bool ItInvoked;
+
+      ItAsync is_a_specification = async () =>
+      {
+          await Task.Run(() =>
+          {
+              Task.Delay(10000);
+              ItInvoked = true;
+          });
+      };
+    }
+
+  public class AsyncContextWithBehavior : IFakeContext
+  {
+      public static bool BecauseInvoked = false;
+      protected static bool ItInvoked = false;
+      public static bool ItWasInvoked => ItInvoked;
+      public static bool ContextInvoked = false;
+      public static bool CleanupInvoked = false;
+
+      EstablishAsync context = async () =>
+      {
+          await Task.Run(() =>
+          {
+              Task.Delay(10000);
+              ContextInvoked = true;
+          });
+      };
+
+      BecauseAsync of = async () =>
+      {
+          await Task.Run(() =>
+          {
+              Task.Delay(10000);
+              BecauseInvoked = true;
+          });
+      };
+
+      Behaves_like<AsyncBehavior> behavior;
+
+      CleanupAsync after = async () =>
+      {
+          await Task.Run(() =>
+          {
+              Task.Delay(10000);
+              CleanupInvoked = true;
+          });
+      };
+
+      public void Reset()
+      {
+          BecauseInvoked = false;
+          ItInvoked = false;
+          ContextInvoked = false;
+          CleanupInvoked = false;
+      }
   }
 }

--- a/src/Machine.Specifications.Tests/Model/ContextTests.cs
+++ b/src/Machine.Specifications.Tests/Model/ContextTests.cs
@@ -124,9 +124,85 @@ namespace Machine.Specifications.Model
     }
 
     [Test]
+    public void ShouldRunSpecification()
+    {
+        ContextWithSingleSpecification.ItInvoked.Should().BeTrue();
+    }
+
+        [Test]
     public void ShouldCleanup()
     {
       ContextWithSingleSpecification.CleanupInvoked.Should().BeTrue();
     }
+  }
+
+  [TestFixture]
+  public class AsyncContextTests : With<AsyncContextWithSingleSpecification>
+  {
+      public override void BeforeEachTest()
+      {
+          base.BeforeEachTest();
+
+          Run(context);
+      }
+
+      [Test]
+      public void ShouldEstablishContext()
+      {
+          AsyncContextWithSingleSpecification.BecauseInvoked.Should().BeTrue();
+      }
+
+      [Test]
+      public void ShouldCallBeforeEach()
+      {
+          AsyncContextWithSingleSpecification.ContextInvoked.Should().BeTrue();
+      }
+
+      [Test]
+      public void ShouldRunSpecification()
+      {
+          AsyncContextWithSingleSpecification.ItInvoked.Should().BeTrue();
+      }
+
+        [Test]
+      public void ShouldCleanup()
+      {
+          AsyncContextWithSingleSpecification.CleanupInvoked.Should().BeTrue();
+      }
+  }
+
+  [TestFixture]
+  public class AsyncBehaviorContextTests : With<AsyncContextWithBehavior>
+  {
+      public override void BeforeEachTest()
+      {
+          base.BeforeEachTest();
+
+          Run(context);
+      }
+
+      [Test]
+      public void ShouldEstablishContext()
+      {
+          AsyncContextWithBehavior.BecauseInvoked.Should().BeTrue();
+      }
+
+      [Test]
+      public void ShouldCallBeforeEach()
+      {
+          AsyncContextWithBehavior.ContextInvoked.Should().BeTrue();
+      }
+
+      [Test, NUnit.Framework.Ignore("Fields not copied back across in this context.")]
+      public void ShouldRunSpecification()
+      {
+          AsyncContextWithBehavior.ItWasInvoked.Should().BeTrue();
+      }
+
+      [Test]
+      public void ShouldCleanup()
+      {
+          AsyncContextWithBehavior.CleanupInvoked.Should().BeTrue();
+      }
   }
 }

--- a/src/Machine.Specifications.Tests/Model/ContextTests.cs
+++ b/src/Machine.Specifications.Tests/Model/ContextTests.cs
@@ -172,6 +172,41 @@ namespace Machine.Specifications.Model
   }
 
   [TestFixture]
+  public class BehaviorContextTests : With<ContextWithBehavior>
+  {
+      public override void BeforeEachTest()
+      {
+          base.BeforeEachTest();
+
+          Run(context);
+      }
+
+      [Test]
+      public void ShouldEstablishContext()
+      {
+          ContextWithBehavior.BecauseInvoked.Should().BeTrue();
+      }
+
+      [Test]
+      public void ShouldCallBeforeEach()
+      {
+          ContextWithBehavior.ContextInvoked.Should().BeTrue();
+      }
+
+      [Test, NUnit.Framework.Ignore("Fields not copied back across in this context.")]
+      public void ShouldRunSpecification()
+      {
+          ContextWithBehavior.ItWasInvoked.Should().BeTrue();
+      }
+
+      [Test]
+      public void ShouldCleanup()
+      {
+          ContextWithBehavior.CleanupInvoked.Should().BeTrue();
+      }
+  }
+
+    [TestFixture]
   public class AsyncBehaviorContextTests : With<AsyncContextWithBehavior>
   {
       public override void BeforeEachTest()

--- a/src/Machine.Specifications/Framework.cs
+++ b/src/Machine.Specifications/Framework.cs
@@ -1,5 +1,21 @@
 namespace Machine.Specifications
 {
+#if ASYNC
+    using System.Threading.Tasks;
+
+    [SetupDelegate]
+    public delegate Task EstablishAsync();
+
+    [ActDelegate]
+    public delegate Task BecauseAsync();
+
+    [AssertDelegate]
+    public delegate Task ItAsync();
+
+    [CleanupDelegate]
+    public delegate Task CleanupAsync();
+#endif
+
     [SetupDelegate]
     public delegate void Establish();
 

--- a/src/Machine.Specifications/Machine.Specifications.csproj
+++ b/src/Machine.Specifications/Machine.Specifications.csproj
@@ -53,7 +53,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <DefineConstants>$(DefineConstants);NET40</DefineConstants>
+    <DefineConstants>$(DefineConstants);NET40;ASYNC</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/src/Machine.Specifications/Machine.Specifications.csproj
+++ b/src/Machine.Specifications/Machine.Specifications.csproj
@@ -56,8 +56,12 @@
     <DefineConstants>$(DefineConstants);NET40</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
+    <DefineConstants>$(DefineConstants);NET45;ASYNC</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETSTANDARD;ASYNC</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/Machine.Specifications/Model/Specification.cs
+++ b/src/Machine.Specifications/Model/Specification.cs
@@ -1,8 +1,6 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
+using Machine.Specifications.Utility;
 using Machine.Specifications.Utility.Internal;
 
 namespace Machine.Specifications.Model
@@ -80,7 +78,7 @@ namespace Machine.Specifications.Model
 
         protected virtual void InvokeSpecificationField()
         {
-            _it.DynamicInvoke();
+            _it.Invoke();
         }
     }
 }


### PR DESCRIPTION
This should resolve #293, although I'd appreciate design feedback with regards to the naming of the new delegates.

These changes apply to .net framework 4.0+ only.

This change introduces new delegates for `Establish`, `Because`, `It`, and `Cleanup` that expect a `Task` return type instead of a `void` return type, allowing an async lambda to be assigned to each. It also changes the way the delegates are invoked so that the `Task`, if present, can be awaited.

I have added unit tests to test the async delegates, and included tests for the `It` delegates in the existing context test. I've also added a test for behaviours with `ItAsync` delegates, but the `ShouldRunSpecification` test fails, although it also fails in a synchronous context, so it's not something I've introduced, I'm possibly just misunderstanding the context of these unit tests.
