### PR TITLE
Support for async/await specifications

### DIFF
--- a/src/Machine.Specifications.Specs/Fixtures/RandomFixture.cs
+++ b/src/Machine.Specifications.Specs/Fixtures/RandomFixture.cs
@@ -1052,11 +1052,22 @@ namespace Machine.Specifications
 
     public class AsyncSpecifications
     {
+        public static bool establish_invoked;
+
         public static bool because_invoked;
 
         public static bool async_it_invoked;
 
         public static bool sync_it_invoked;
+
+        public static bool cleanup_invoked;
+
+        Establish context = async () =>
+        {
+            establish_invoked = true;
+
+            await Task.Delay(10);
+        };
 
         Because of = async () =>
         {
@@ -1071,6 +1082,12 @@ namespace Machine.Specifications
         It should_invoke_async = async () =>
         {
             async_it_invoked = true;
+            await Task.Delay(10);
+        };
+
+        Cleanup after = async () =>
+        {
+            cleanup_invoked = true;
             await Task.Delay(10);
         };
     }

--- a/src/Machine.Specifications.Specs/Fixtures/RandomFixture.cs
+++ b/src/Machine.Specifications.Specs/Fixtures/RandomFixture.cs
@@ -1078,13 +1078,19 @@ namespace Machine.Specifications
     public class AsyncSpecificationsWithExceptions
     {
         Because of = async () =>
-            throw new Exception();
+        {
+            throw new InvalidOperationException(""something went wrong"");
+        };
 
         It should_invoke_sync = () =>
-            throw new Exception();
+        {
+            throw new InvalidOperationException(""something went wrong"");
+        };
 
         It should_invoke_async = async () =>
-            throw new Exception();
+        {
+            throw new InvalidOperationException(""something went wrong"");
+        };
     }
 }";
     }

--- a/src/Machine.Specifications.Specs/Fixtures/RandomFixture.cs
+++ b/src/Machine.Specifications.Specs/Fixtures/RandomFixture.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Diagnostics;
 using System.Reflection;
+using System.Threading.Tasks;
 using Machine.Specifications;
 
 namespace Example.Random
@@ -1047,6 +1048,43 @@ namespace Machine.Specifications
             context_invoked = false;
             cleanup_invoked = false;
         }
+    }
+
+    public class AsyncSpecifications
+    {
+        public static bool because_invoked;
+
+        public static bool async_it_invoked;
+
+        public static bool sync_it_invoked;
+
+        Because of = async () =>
+        {
+            because_invoked = true;
+
+            await Task.Delay(10);
+        };
+
+        It should_invoke_sync = () =>
+            sync_it_invoked = true;
+
+        It should_invoke_async = async () =>
+        {
+            async_it_invoked = true;
+            await Task.Delay(10);
+        };
+    }
+
+    public class AsyncSpecificationsWithExceptions
+    {
+        Because of = async () =>
+            throw new Exception();
+
+        It should_invoke_sync = () =>
+            throw new Exception();
+
+        It should_invoke_async = async () =>
+            throw new Exception();
     }
 }";
     }

--- a/src/Machine.Specifications.Specs/Runner/AsyncDelegateRunnerSpecs.cs
+++ b/src/Machine.Specifications.Specs/Runner/AsyncDelegateRunnerSpecs.cs
@@ -15,13 +15,18 @@ namespace Machine.Specifications.Specs.Runner
         {
             specs = GetFramework("AsyncSpecifications");
 
+            specs.ToDynamic().establish_invoked = false;
             specs.ToDynamic().because_invoked = false;
             specs.ToDynamic().async_it_invoked = false;
             specs.ToDynamic().sync_it_invoked = false;
+            specs.ToDynamic().cleanup_invoked = false;
         };
 
         Because of = () =>
             Run(specs);
+
+        It should_call_establish = () =>
+            specs.ToDynamic().establish_invoked.ShouldBeTrue();
 
         It should_call_because = () =>
             specs.ToDynamic().because_invoked.ShouldBeTrue();
@@ -31,6 +36,9 @@ namespace Machine.Specifications.Specs.Runner
 
         It should_call_sync_spec = () =>
             specs.ToDynamic().sync_it_invoked.ShouldBeTrue();
+
+        It should_call_cleanup = () =>
+            specs.ToDynamic().cleanup_invoked.ShouldBeTrue();
     }
 
     [Subject("Async Delegate Runner")]

--- a/src/Machine.Specifications.Specs/Runner/AsyncDelegateRunnerSpecs.cs
+++ b/src/Machine.Specifications.Specs/Runner/AsyncDelegateRunnerSpecs.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Linq;
+using Machine.Specifications.Factories;
+using Machine.Specifications.Runner;
+using Machine.Specifications.Runner.Impl;
+
+namespace Machine.Specifications.Specs.Runner
+{
+    [Subject("Async Delegate Runner")]
+    public class when_running_async_specifications : RandomRunnerSpecs
+    {
+        static Type specs;
+
+        Establish context = () =>
+        {
+            specs = GetFramework("AsyncSpecifications");
+
+            specs.ToDynamic().because_invoked = false;
+            specs.ToDynamic().async_it_invoked = false;
+            specs.ToDynamic().sync_it_invoked = false;
+        };
+
+        Because of = () =>
+            Run(specs);
+
+        It should_call_because = () =>
+            specs.ToDynamic().because_invoked.ShouldBeTrue();
+
+        It should_call_async_spec = () =>
+            specs.ToDynamic().async_it_invoked.ShouldBeTrue();
+
+        It should_call_sync_spec = () =>
+            specs.ToDynamic().sync_it_invoked.ShouldBeTrue();
+    }
+
+    [Subject("Async Delegate Runner")]
+    public class when_running_async_specifications_with_exceptions : RandomRunnerSpecs
+    {
+        static ContextFactory factory;
+
+        static Type specs;
+
+        static Result[] results;
+
+        Establish context = () =>
+            factory = new ContextFactory();
+
+        Because of = () =>
+        {
+            specs = GetFramework("AsyncSpecificationsWithExceptions");
+
+            var context = factory.CreateContextFrom(Activator.CreateInstance(specs));
+
+            results = ContextRunnerFactory
+                .GetContextRunnerFor(context)
+                .Run(context,
+                    new RunListenerBase(),
+                    RunOptions.Default,
+                    Array.Empty<ICleanupAfterEveryContextInAssembly>(),
+                    Array.Empty<ISupplementSpecificationResults>())
+                .ToArray();
+        };
+
+        It should_run_two_specs = () =>
+            results.Length.ShouldEqual(2);
+
+        It should_have_failures = () =>
+            results.ShouldEachConformTo(x => !x.Passed);
+    }
+}

--- a/src/Machine.Specifications/Model/Specification.cs
+++ b/src/Machine.Specifications/Model/Specification.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using Machine.Specifications.Runner.Impl;
 using Machine.Specifications.Utility.Internal;
 
 namespace Machine.Specifications.Model
@@ -80,7 +81,8 @@ namespace Machine.Specifications.Model
 
         protected virtual void InvokeSpecificationField()
         {
-            _it.DynamicInvoke();
+            var runner = new DelegateRunner(_it);
+            runner.Execute();
         }
     }
 }

--- a/src/Machine.Specifications/Runner/Impl/AsyncManualResetEvent.cs
+++ b/src/Machine.Specifications/Runner/Impl/AsyncManualResetEvent.cs
@@ -1,0 +1,32 @@
+﻿using System.Threading.Tasks;
+
+namespace Machine.Specifications.Runner.Impl
+{
+    internal class AsyncManualResetEvent
+    {
+        private volatile TaskCompletionSource<bool> source = new TaskCompletionSource<bool>();
+
+        public AsyncManualResetEvent()
+        {
+            source.TrySetResult(true);
+        }
+
+        public void Reset()
+        {
+            if (source.Task.IsCompleted)
+            {
+                source = new TaskCompletionSource<bool>();
+            }
+        }
+
+        public void Set()
+        {
+            source.TrySetResult(true);
+        }
+
+        public Task WaitAsync()
+        {
+            return source.Task;
+        }
+    }
+}

--- a/src/Machine.Specifications/Runner/Impl/AsyncSynchronizationContext.cs
+++ b/src/Machine.Specifications/Runner/Impl/AsyncSynchronizationContext.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Machine.Specifications.Runner.Impl
+{
+    internal class AsyncSynchronizationContext : SynchronizationContext
+    {
+        private readonly SynchronizationContext inner;
+
+        private readonly AsyncManualResetEvent events = new AsyncManualResetEvent();
+
+        private int callCount;
+
+        private Exception exception;
+
+        public AsyncSynchronizationContext(SynchronizationContext inner)
+        {
+            this.inner = inner;
+        }
+
+        private void Execute(SendOrPostCallback callback, object state)
+        {
+            try
+            {
+                callback(state);
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+            finally
+            {
+                OperationCompleted();
+            }
+        }
+
+        public override void OperationCompleted()
+        {
+            var count = Interlocked.Decrement(ref callCount);
+
+            if (count == 0)
+            {
+                events.Set();
+            }
+        }
+
+        public override void OperationStarted()
+        {
+            Interlocked.Increment(ref callCount);
+
+            events.Reset();
+        }
+
+        public override void Post(SendOrPostCallback d, object state)
+        {
+            OperationStarted();
+
+            try
+            {
+                if (inner == null)
+                {
+                    ThreadPool.QueueUserWorkItem(_ => Execute(d, state));
+                }
+                else
+                {
+                    inner.Post(_ => Execute(d, state), null);
+                }
+            }
+            catch
+            {
+                // ignored
+            }
+        }
+
+        public override void Send(SendOrPostCallback d, object state)
+        {
+            try
+            {
+                if (inner == null)
+                {
+                    d(state);
+                }
+                else
+                {
+                    inner.Send(d, state);
+                }
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+        }
+
+        public async Task<Exception> WaitAsync()
+        {
+            await events.WaitAsync();
+
+            return exception;
+        }
+    }
+}

--- a/src/Machine.Specifications/Runner/Impl/DelegateRunner.cs
+++ b/src/Machine.Specifications/Runner/Impl/DelegateRunner.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Threading;
+
+namespace Machine.Specifications.Runner.Impl
+{
+    internal class DelegateRunner
+    {
+        private readonly Delegate target;
+
+        private readonly object[] args;
+
+        public DelegateRunner(Delegate target, params object[] args)
+        {
+            this.target = target;
+            this.args = args;
+        }
+
+        public void Execute()
+        {
+            var currentContext = SynchronizationContext.Current;
+
+            var context = new AsyncSynchronizationContext(currentContext);
+
+            SynchronizationContext.SetSynchronizationContext(context);
+
+            try
+            {
+                target.DynamicInvoke(args);
+
+                var exception = context.WaitAsync().Result;
+
+                if (exception != null)
+                {
+                    throw exception;
+                }
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(currentContext);
+            }
+        }
+    }
+}

--- a/src/Machine.Specifications/Utility/RandomExtensionMethods.cs
+++ b/src/Machine.Specifications/Utility/RandomExtensionMethods.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-
+using Machine.Specifications.Runner.Impl;
 using Machine.Specifications.Sdk;
 
 namespace Machine.Specifications.Utility
@@ -19,7 +19,13 @@ namespace Machine.Specifications.Utility
 
         internal static void InvokeAll(this IEnumerable<Delegate> contextActions, params object[] args)
         {
-            contextActions.AllNonNull().Select<Delegate, Action>(x => () => x.DynamicInvoke(args)).InvokeAll();
+            contextActions.AllNonNull().Select<Delegate, Action>(x => () => x.InvokeAsync(args)).InvokeAll();
+        }
+
+        internal static void InvokeAsync(this Delegate target, params object[] args)
+        {
+            var runner = new DelegateRunner(target, args);
+            runner.Execute();
         }
 
         static IEnumerable<T> AllNonNull<T>(this IEnumerable<T> elements) where T : class


### PR DESCRIPTION
Fixed #293 

This is inspired by the xUnit strategy for executing `async void` methods.

This lets you run specs using the following syntax:

```c#
class when_using_async
{
    Establish context = async () =>
        await Task.Delay(10);

    Because of = async () =>
        await Task.Delay(10);

    It should_invoke_async = async () =>
        await Task.Delay(10);

    Cleanup after = async () =>
        await Task.Delay(10);
}
```