### PR TITLE
Performance Improvement - Perform test filtering earlier in process

### DIFF
--- a/src/Machine.Specifications.Runner.Console.Specs/ProgramSpecs.cs
+++ b/src/Machine.Specifications.Runner.Console.Specs/ProgramSpecs.cs
@@ -162,7 +162,7 @@ namespace Machine.Specifications.ConsoleRunner.Specs
             console.Lines.ShouldContain(l => l.Contains("hi scott, love you, miss you."));
 
         It should_separate_failures_from_the_rest_of_the_test_run = () =>
-            console.Output.ShouldMatchRegex(String.Format("\\S{0}{0}Failures:{0}{0}\\S", Regex.Escape(Environment.NewLine)));
+            console.Output.ShouldMatchRegex(String.Format("{0}Failures:{0}{0}\\S", Regex.Escape(Environment.NewLine)));
     }
 
     [Subject("Console runner")]
@@ -189,7 +189,7 @@ namespace Machine.Specifications.ConsoleRunner.Specs
             console.Lines.ShouldContain(l => l.Contains("hi scott, love you, miss you."));
 
         It should_separate_failures_from_the_rest_of_the_test_run = () =>
-            console.Output.ShouldMatchRegex(String.Format("\\S{0}{0}{0}Failures:{0}{0}\\S", Regex.Escape(Environment.NewLine)));
+            console.Output.ShouldMatchRegex(String.Format("{0}Failures:{0}{0}\\S", Regex.Escape(Environment.NewLine)));
     }
 
     [Subject("Console runner")]

--- a/src/Machine.Specifications.Specs/CompileContext.cs
+++ b/src/Machine.Specifications.Specs/CompileContext.cs
@@ -34,7 +34,7 @@ namespace Machine.Specifications.Specs
                 .Emit(filename);
 
             if (!result.Success)
-                throw new InvalidOperationException();
+                throw new InvalidOperationException(result.Diagnostics[0].GetMessage());
 #else
             var parameters = new CompilerParameters
             {

--- a/src/Machine.Specifications.Specs/Fixtures/LargeFixture.cs
+++ b/src/Machine.Specifications.Specs/Fixtures/LargeFixture.cs
@@ -17,10 +17,21 @@ using Machine.Specifications;
 
 namespace Example.Large
 {
-
     public class when_there_are_many_contexts
     {
+        public static bool Created = false;
+
+        public when_there_are_many_contexts()
+        {
+            Created = true;
+        }
+
         It spec = () => {};
+    }
+
+    public static class OtherTests
+    {
+        public static bool Created = false;
     }
 
 ");
@@ -30,6 +41,11 @@ namespace Example.Large
                 sb.AppendLine($@"
     public class when_there_are_many_contexts_{i}
     {{
+        public when_there_are_many_contexts_{i}()
+        {{
+            OtherTests.Created = true;
+        }}
+
         It spec = () => {{}};
     }}");
             }

--- a/src/Machine.Specifications.Specs/Fixtures/LargeFixture.cs
+++ b/src/Machine.Specifications.Specs/Fixtures/LargeFixture.cs
@@ -1,0 +1,43 @@
+﻿using System.Text;
+
+namespace Machine.Specifications.Specs.Fixtures
+{
+    public class LargeFixture
+    {
+        public static string CreateCode(int specCount)
+        {
+            var sb = new StringBuilder();
+
+            sb.AppendLine(@"
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Threading.Tasks;
+using Machine.Specifications;
+
+namespace Example.Large
+{
+
+    public class when_there_are_many_contexts
+    {
+        It spec = () => {};
+    }
+
+");
+
+            for (var i = 1; i <= specCount; i++)
+            {
+                sb.AppendLine($@"
+    public class when_there_are_many_contexts_{i}
+    {{
+        It spec = () => {{}};
+    }}");
+            }
+
+            sb.AppendLine(@"
+}");
+
+            return sb.ToString();
+        }
+    }
+}

--- a/src/Machine.Specifications.Specs/Runner/SpecificationRunnerSpecs.cs
+++ b/src/Machine.Specifications.Specs/Runner/SpecificationRunnerSpecs.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using Machine.Specifications.Runner;
 using Machine.Specifications.Runner.Impl;
@@ -689,6 +691,48 @@ namespace Machine.Specifications.Specs.Runner
 
         It should_succeed = () =>
             testListener.LastResult.Passed.ShouldBeTrue();
+    }
+
+    [Subject("Specification Runner")]
+    public class when_running_a_single_spec_out_of_a_large_number_of_specifications : RunnerSpecs
+    {
+        static Type when_a_context_has_many_specifications;
+        static TimeSpan elapsed { get; set; }
+
+        Establish context = () =>
+        {
+            using (var compiler = new CompileContext())
+            {
+                var assemblyPath = compiler.Compile(LargeFixture.CreateCode(10000));
+                var assembly = Assembly.LoadFile(assemblyPath);
+
+                when_a_context_has_many_specifications = assembly.GetType("Example.Large.when_there_are_many_contexts");
+            }
+        };
+
+        Because of = () =>
+        {
+            var runner = new DefaultRunner(testListener, new RunOptions(
+                Enumerable.Empty<string>(),
+                Enumerable.Empty<string>(),
+                new[] {when_a_context_has_many_specifications.FullName})
+            );
+
+            var sw = Stopwatch.StartNew();
+            runner.RunAssembly(when_a_context_has_many_specifications.Assembly);
+            sw.Stop();
+            elapsed = sw.Elapsed;
+        };
+
+        It should_run_the_single_specification = () =>
+        {
+            testListener.SpecCount.ShouldEqual(1);
+        };
+
+        It should_run_in_a_reasonable_period_of_time = () =>
+        {
+            elapsed.ShouldBeLessThan(TimeSpan.FromSeconds(1));
+        };
     }
 
     public class RandomRunnerSpecs : RunnerSpecs

--- a/src/Machine.Specifications.Specs/Runner/SpecificationRunnerSpecs.cs
+++ b/src/Machine.Specifications.Specs/Runner/SpecificationRunnerSpecs.cs
@@ -697,6 +697,7 @@ namespace Machine.Specifications.Specs.Runner
     public class when_running_a_single_spec_out_of_a_large_number_of_specifications : RunnerSpecs
     {
         static Type when_a_context_has_many_specifications;
+        static Type filtered_out_spec;
         static TimeSpan elapsed { get; set; }
 
         Establish context = () =>
@@ -707,6 +708,7 @@ namespace Machine.Specifications.Specs.Runner
                 var assembly = Assembly.LoadFile(assemblyPath);
 
                 when_a_context_has_many_specifications = assembly.GetType("Example.Large.when_there_are_many_contexts");
+                filtered_out_spec = assembly.GetType("Example.Large.OtherTests");
             }
         };
 
@@ -732,6 +734,18 @@ namespace Machine.Specifications.Specs.Runner
         It should_run_in_a_reasonable_period_of_time = () =>
         {
             elapsed.ShouldBeLessThan(TimeSpan.FromSeconds(1));
+        };
+
+        It should_have_created_the_test_instance = () =>
+        {
+            var fieldInfo = when_a_context_has_many_specifications.GetField("Created");
+            ((bool) fieldInfo.GetValue(null)).ShouldBeTrue();
+        };
+
+        It should_have_not_have_created_any_of_the_filtered_out_tests = () =>
+        {
+            var fieldInfo = filtered_out_spec.GetField("Created");
+            ((bool) fieldInfo.GetValue(null)).ShouldBeFalse();
         };
     }
 

--- a/src/Machine.Specifications/Explorers/AssemblyExplorer.cs
+++ b/src/Machine.Specifications/Explorers/AssemblyExplorer.cs
@@ -145,7 +145,7 @@ namespace Machine.Specifications.Explorers
 
                 var filteredTypesWithTags = filteredTypes.Select(type => (Type: type, Tags: extractor.ExtractTags(type)));
 
-                if (includeTags.Any() )
+                if (includeTags.Any())
                 {
                     filteredTypesWithTags = filteredTypesWithTags.Where(x => x.Tags.Intersect(includeTags).Any());
                 }

--- a/src/Machine.Specifications/Explorers/AssemblyExplorer.cs
+++ b/src/Machine.Specifications/Explorers/AssemblyExplorer.cs
@@ -19,12 +19,7 @@ namespace Machine.Specifications.Explorers
             _contextFactory = new ContextFactory();
         }
 
-        public Context FindContexts(Type type)
-        {
-            return FindContexts(type, options: null);
-        }
-
-        public Context FindContexts(Type type, RunOptions options)
+        public Context FindContexts(Type type, RunOptions options = null)
         {
             var types = new[] {type};
 
@@ -35,12 +30,7 @@ namespace Machine.Specifications.Explorers
                 .FirstOrDefault();
         }
 
-        public Context FindContexts(FieldInfo info)
-        {
-            return FindContexts(info, null);
-        }
-
-        public Context FindContexts(FieldInfo info, RunOptions options)
+        public Context FindContexts(FieldInfo info, RunOptions options = null)
         {
             var types = new[] {info.DeclaringType};
 

--- a/src/Machine.Specifications/Explorers/AssemblyExplorer.cs
+++ b/src/Machine.Specifications/Explorers/AssemblyExplorer.cs
@@ -150,7 +150,7 @@ namespace Machine.Specifications.Explorers
                     filteredTypesWithTags = filteredTypesWithTags.Where(x => x.Tags.Intersect(includeTags).Any());
                 }
 
-                if (excludeTags.Any() )
+                if (excludeTags.Any())
                 {
                     filteredTypesWithTags = filteredTypesWithTags.Where(x => !x.Tags.Intersect(excludeTags).Any());
                 }

--- a/src/Machine.Specifications/Runner/Impl/AssemblyRunner.cs
+++ b/src/Machine.Specifications/Runner/Impl/AssemblyRunner.cs
@@ -44,18 +44,17 @@ namespace Machine.Specifications.Runner.Impl
 
             try
             {
-                hasExecutableSpecifications = contexts.Any(x => x.HasExecutableSpecifications);
-
                 var globalCleanups = _explorer.FindAssemblyWideContextCleanupsIn(assembly).ToList();
                 var specificationSupplements = _explorer.FindSpecificationSupplementsIn(assembly).ToList();
 
-                if (hasExecutableSpecifications)
-                {
-                    _assemblyStart(assembly);
-                }
-
                 foreach (var context in contexts)
                 {
+                    if (!hasExecutableSpecifications)
+                    {
+                        _assemblyStart(assembly);
+                        hasExecutableSpecifications = true;
+                    }
+
                     RunContext(context, globalCleanups, specificationSupplements);
                 }
             }

--- a/src/Machine.Specifications/Utility/KeyValuePairExtensions.cs
+++ b/src/Machine.Specifications/Utility/KeyValuePairExtensions.cs
@@ -2,7 +2,7 @@
 
 namespace Machine.Specifications.Runner.Impl
 {
-    static class KeyValuePairExtensions
+    internal static class KeyValuePairExtensions
     {
         public static void Deconstruct<TKey, TValue>(
             this KeyValuePair<TKey, TValue> kvp,

--- a/src/Machine.Specifications/Utility/KeyValuePairExtensions.cs
+++ b/src/Machine.Specifications/Utility/KeyValuePairExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+
+namespace Machine.Specifications.Runner.Impl
+{
+    static class KeyValuePairExtensions
+    {
+        public static void Deconstruct<TKey, TValue>(
+            this KeyValuePair<TKey, TValue> kvp,
+            out TKey key,
+            out TValue value)
+        {
+            key = kvp.Key;
+            value = kvp.Value;
+        }
+    }
+}


### PR DESCRIPTION
Move test filtering to `AssemblyExplorer` where filtering can be carried out before the `Context` is created which involves creating an instance of the test class.  Filtering can be done just by using the `Type` and is much faster when there are a large number specifications in the test assembly, as it saves instantiating a context for each specification.  Sorting by namespace is now carried out after the filter to reduce the size of the sort required.

There is a slight change in behaviour, if an illegal test (e.g. test with two establishes) is excluded from the run, it no longer is called out as an error whereas it did previously.   Previously the `ContextFactory` would have failed to create a context for the illegal test, but now the test is excluded (by tags or class name) before the context is created so the error is not reported.  The error is still reported when the bad test is included in the test run.