### PR TITLE
Use ValueTask and generic exceptions for catch

### DIFF
--- a/src/Machine.Specifications.Core.Specs/.editorconfig
+++ b/src/Machine.Specifications.Core.Specs/.editorconfig
@@ -24,14 +24,14 @@ dotnet_naming_symbols.specs_class.applicable_kinds = class
 dotnet_naming_symbols.specs_class.applicable_accessibilities = private, internal
 
 # Naming rules
-dotnet_naming_rule.static_field_should_be_snake_case.severity = error
+dotnet_naming_rule.static_field_should_be_snake_case.severity = warning
 dotnet_naming_rule.static_field_should_be_snake_case.symbols = static_field
 dotnet_naming_rule.static_field_should_be_snake_case.style = snake_case
 
-dotnet_naming_rule.machine_delegate_should_be_snake_case.severity = error
+dotnet_naming_rule.machine_delegate_should_be_snake_case.severity = warning
 dotnet_naming_rule.machine_delegate_should_be_snake_case.symbols = specs_delegate
 dotnet_naming_rule.machine_delegate_should_be_snake_case.style = snake_case
 
-dotnet_naming_rule.specs_class_should_be_snake_case.severity = error
+dotnet_naming_rule.specs_class_should_be_snake_case.severity = warning
 dotnet_naming_rule.specs_class_should_be_snake_case.symbols = specs_class
 dotnet_naming_rule.specs_class_should_be_snake_case.style = snake_case

--- a/src/Machine.Specifications.Core.Specs/CatchSpecs.cs
+++ b/src/Machine.Specifications.Core.Specs/CatchSpecs.cs
@@ -4,10 +4,10 @@ using System.Threading.Tasks;
 namespace Machine.Specifications.Specs
 {
     [Subject(typeof(Catch))]
-    class when_calling_Catch_Exception_with_an_Action
+    class when_calling_catch_exception_with_an_action
     {
         [Subject(typeof(Catch))]
-        class with_a_throwing_Action
+        class with_a_throwing_action
         {
             static ArgumentException an_exception;
 
@@ -24,7 +24,7 @@ namespace Machine.Specifications.Specs
         }
 
         [Subject(typeof(Catch))]
-        class with_a_non_throwing_Action
+        class with_a_non_throwing_action
         {
             static string action_side_effect;
 
@@ -42,16 +42,16 @@ namespace Machine.Specifications.Specs
     }
 
     [Subject(typeof(Catch))]
-    class when_calling_Catch_Exception_with_a_Func
+    class when_calling_catch_exception_with_a_func
     {
-        static ArgumentException AnException = new ArgumentException();
+        static ArgumentException an_exception = new ArgumentException();
 
-        static string ThrowingProperty => throw AnException;
+        static string ThrowingProperty => throw an_exception;
 
         static string NonThrowingProperty => "hi";
 
         [Subject(typeof(Catch))]
-        class with_a_throwing_Func
+        class with_a_throwing_func
         {
             static Exception result;
 
@@ -59,11 +59,11 @@ namespace Machine.Specifications.Specs
                 result = Catch.Exception(() => ThrowingProperty);
 
             It should_return_the_same_exception = () =>
-                result.ShouldBeTheSameAs(AnException);
+                result.ShouldBeTheSameAs(an_exception);
         }
 
         [Subject(typeof(Catch))]
-        class with_a_non_throwing_Func
+        class with_a_non_throwing_func
         {
             static Exception result;
 
@@ -74,61 +74,6 @@ namespace Machine.Specifications.Specs
 
             It should_access_the_propety = () =>
                 property_value.ShouldEqual("hi");
-
-            It should_return_null = () =>
-                result.ShouldBeNull();
-        }
-    }
-
-    [Subject(typeof(Catch))]
-    class when_calling_Catch_Only_with_an_Action
-    {
-        [Subject(typeof(Catch))]
-        class with_a_throwing_Action_which_matches_exception_to_be_caught
-        {
-            static ArgumentException an_exception;
-
-            static Exception result;
-
-            Establish context = () =>
-                an_exception = new ArgumentException();
-
-            Because of = () =>
-                result = Catch.Only<ArgumentException>(() => throw an_exception);
-
-            It should_return_the_same_exception = () =>
-                result.ShouldBeTheSameAs(an_exception);
-        }
-
-        [Subject(typeof(Catch))]
-        class with_a_throwing_Action_which_doesnt_match_exception_to_be_caught
-        {
-            static ArgumentException an_exception;
-
-            static Exception result;
-
-            Establish context = () =>
-                an_exception = new ArgumentException();
-
-            Because of = () =>
-                result = Catch.Exception(() => Catch.Only<InvalidOperationException>(() => throw an_exception));
-
-            It should_return_the_same_exception = () =>
-                result.ShouldBeTheSameAs(an_exception);
-        }
-
-        [Subject(typeof(Catch))]
-        class with_a_non_throwing_Action
-        {
-            static string action_side_effect;
-
-            static Exception result;
-
-            Because of = () =>
-                result = Catch.Only<ArgumentException>(() => action_side_effect = "hi");
-
-            It should_access_the_propety = () =>
-                action_side_effect.ShouldEqual("hi");
 
             It should_return_null = () =>
                 result.ShouldBeNull();
@@ -177,6 +122,68 @@ namespace Machine.Specifications.Specs
 
             It should_contain_message = () =>
                 exception.Message.ShouldEqual("You must use Catch.ExceptionAsync for async methods");
+        }
+
+        [Subject(typeof(Catch))]
+        class using_value_task
+        {
+            static ValueTask Test() => throw new ArgumentNullException();
+
+            Because of = async () =>
+                exception = await Catch.ExceptionAsync(Test);
+
+            It should_return_exception = () =>
+                exception.ShouldBeOfExactType<ArgumentNullException>();
+        }
+
+        [Subject(typeof(Catch))]
+        class using_value_task_that_works
+        {
+            static string result;
+
+            static ValueTask Test()
+            {
+                result = "done";
+
+                return new ValueTask(Task.Run(() => { }));
+            }
+
+            Because of = async () =>
+                exception = await Catch.ExceptionAsync(Test);
+
+            It should_complete = () =>
+                result.ShouldEqual("done");
+        }
+
+        [Subject(typeof(Catch))]
+        class using_generic_value_task
+        {
+            static ValueTask<int> Test() => throw new ArgumentNullException();
+
+            Because of = async () =>
+                exception = await Catch.ExceptionAsync(Test);
+
+            It should_return_exception = () =>
+                exception.ShouldBeOfExactType<ArgumentNullException>();
+        }
+
+        [Subject(typeof(Catch))]
+        class using_generic_value_task_that_works
+        {
+            static string result;
+
+            static ValueTask<int> Test()
+            {
+                result = "done";
+
+                return new ValueTask<int>(4);
+            }
+
+            Because of = async () =>
+                exception = await Catch.ExceptionAsync(Test);
+
+            It should_complete = () =>
+                result.ShouldEqual("done");
         }
     }
 }

--- a/src/Machine.Specifications.Core/Catch.cs
+++ b/src/Machine.Specifications.Core/Catch.cs
@@ -5,11 +5,11 @@ namespace Machine.Specifications
 {
     public static class Catch
     {
-        public static Exception Exception(Action throwingAction)
+        public static Exception Exception(Action action)
         {
             try
             {
-                throwingAction();
+                action();
             }
             catch (Exception ex)
             {
@@ -19,7 +19,7 @@ namespace Machine.Specifications
             return null;
         }
 
-        public static Exception Exception<T>(Func<T> throwingFunc)
+        public static Exception Exception(Func<object> throwingFunc)
         {
             Task task;
 
@@ -27,9 +27,9 @@ namespace Machine.Specifications
             {
                 task = throwingFunc() as Task;
             }
-            catch (Exception exception)
+            catch (Exception ex)
             {
-                return exception;
+                return ex;
             }
 
             if (task != null)
@@ -40,11 +40,11 @@ namespace Machine.Specifications
             return null;
         }
 
-        public static async Task<Exception> ExceptionAsync(Func<Task> throwingAction)
+        public static async Task<Exception> ExceptionAsync(Func<Task> action)
         {
             try
             {
-                await throwingAction();
+                await action();
             }
             catch (Exception ex)
             {
@@ -54,16 +54,29 @@ namespace Machine.Specifications
             return null;
         }
 
-        public static TException Only<TException>(Action throwingAction)
-            where TException : Exception
+        public static async Task<Exception> ExceptionAsync(Func<ValueTask> action)
         {
             try
             {
-                throwingAction();
+                await action();
             }
-            catch (TException exception)
+            catch (Exception ex)
             {
-                return exception;
+                return ex;
+            }
+
+            return null;
+        }
+
+        public static async Task<Exception> ExceptionAsync<T>(Func<ValueTask<T>> action)
+        {
+            try
+            {
+                await action();
+            }
+            catch (Exception ex)
+            {
+                return ex;
             }
 
             return null;

--- a/src/Machine.Specifications.Core/Machine.Specifications.Core.csproj
+++ b/src/Machine.Specifications.Core/Machine.Specifications.Core.csproj
@@ -16,6 +16,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Machine.Specifications.Interfaces\Machine.Specifications.Interfaces.csproj" />
   </ItemGroup>
 

--- a/src/Machine.Specifications.Runner.Utility.Specs/.editorconfig
+++ b/src/Machine.Specifications.Runner.Utility.Specs/.editorconfig
@@ -24,14 +24,14 @@ dotnet_naming_symbols.specs_class.applicable_kinds = class
 dotnet_naming_symbols.specs_class.applicable_accessibilities = private, internal
 
 # Naming rules
-dotnet_naming_rule.static_field_should_be_snake_case.severity = error
+dotnet_naming_rule.static_field_should_be_snake_case.severity = warning
 dotnet_naming_rule.static_field_should_be_snake_case.symbols = static_field
 dotnet_naming_rule.static_field_should_be_snake_case.style = snake_case
 
-dotnet_naming_rule.machine_delegate_should_be_snake_case.severity = error
+dotnet_naming_rule.machine_delegate_should_be_snake_case.severity = warning
 dotnet_naming_rule.machine_delegate_should_be_snake_case.symbols = specs_delegate
 dotnet_naming_rule.machine_delegate_should_be_snake_case.style = snake_case
 
-dotnet_naming_rule.specs_class_should_be_snake_case.severity = error
+dotnet_naming_rule.specs_class_should_be_snake_case.severity = warning
 dotnet_naming_rule.specs_class_should_be_snake_case.symbols = specs_class
 dotnet_naming_rule.specs_class_should_be_snake_case.style = snake_case

--- a/src/Machine.Specifications.Should.Specs/.editorconfig
+++ b/src/Machine.Specifications.Should.Specs/.editorconfig
@@ -24,14 +24,14 @@ dotnet_naming_symbols.specs_class.applicable_kinds = class
 dotnet_naming_symbols.specs_class.applicable_accessibilities = private, internal
 
 # Naming rules
-dotnet_naming_rule.static_field_should_be_snake_case.severity = error
+dotnet_naming_rule.static_field_should_be_snake_case.severity = warning
 dotnet_naming_rule.static_field_should_be_snake_case.symbols = static_field
 dotnet_naming_rule.static_field_should_be_snake_case.style = snake_case
 
-dotnet_naming_rule.machine_delegate_should_be_snake_case.severity = error
+dotnet_naming_rule.machine_delegate_should_be_snake_case.severity = warning
 dotnet_naming_rule.machine_delegate_should_be_snake_case.symbols = specs_delegate
 dotnet_naming_rule.machine_delegate_should_be_snake_case.style = snake_case
 
-dotnet_naming_rule.specs_class_should_be_snake_case.severity = error
+dotnet_naming_rule.specs_class_should_be_snake_case.severity = warning
 dotnet_naming_rule.specs_class_should_be_snake_case.symbols = specs_class
 dotnet_naming_rule.specs_class_should_be_snake_case.style = snake_case

--- a/src/Machine.Specifications.Should.Specs/Utility/ObjectGraphHelperSpecs.cs
+++ b/src/Machine.Specifications.Should.Specs/Utility/ObjectGraphHelperSpecs.cs
@@ -140,7 +140,7 @@ namespace Machine.Specifications.Should.Specs.Utility
     }
 
     [Subject(typeof(ObjectGraphHelper))]
-    class when_getting_a_sequence_graph_with_an_IEnumerable
+    class when_getting_a_sequence_graph_with_an_enumerable
     {
         static IEnumerable<string> sequence;
 
@@ -213,7 +213,7 @@ namespace Machine.Specifications.Should.Specs.Utility
     }
 
     [Subject(typeof(ObjectGraphHelper))]
-    class when_expected_Inner_value_is_null
+    class when_expected_inner_value_is_null
     {
         static Model actual_model;
 
@@ -223,14 +223,14 @@ namespace Machine.Specifications.Should.Specs.Utility
             actual_model = new Model {Inner = new InnerModel()};
 
         Because of = () =>
-            thrown_exception = Catch.Only<SpecificationException>(() => actual_model.ShouldBeLike(new Model() { Inner = null }));
+            thrown_exception = Catch.Exception(() => actual_model.ShouldBeLike(new Model() { Inner = null }));
 
         It should_throw_specification_exception = () =>
             thrown_exception.ShouldBeOfExactType<SpecificationException>();
     }
 
     [Subject(typeof(ObjectGraphHelper))]
-    class when_actual_Inner_value_is_null
+    class when_actual_inner_value_is_null
     {
         static Model actual_model;
 
@@ -240,7 +240,7 @@ namespace Machine.Specifications.Should.Specs.Utility
             actual_model = new Model { Inner = null };
 
         Because of = () =>
-            thrown_exception = Catch.Only<SpecificationException>(() => actual_model.ShouldBeLike(new Model() { Inner = new InnerModel() }));
+            thrown_exception = Catch.Exception(() => actual_model.ShouldBeLike(new Model() { Inner = new InnerModel() }));
 
         It should_throw_specification_exception = () =>
             thrown_exception.ShouldBeOfExactType<SpecificationException>();
@@ -257,7 +257,7 @@ namespace Machine.Specifications.Should.Specs.Utility
             actual_model = new Model { Inner = null };
 
         Because of = () =>
-            thrown_exception = Catch.Only<SpecificationException>(() => actual_model.ShouldBeLike(new Model() { Inner = null }));
+            thrown_exception = Catch.Exception(() => actual_model.ShouldBeLike(new Model() { Inner = null }));
 
         It should_throw_specification_exception = () =>
             thrown_exception.ShouldBeNull();


### PR DESCRIPTION
The reason that the `Only<T>` function is being deprecated is that it breaks AAA testing, whereby the Action is actually also performing the Assert. Proper tests should be composed by calling `Catch.Exception()` and then asserting the exception type using `exception.ShouldBeOfExactType<T>()`.