### PR TITLE
Capture stacktrace of exceptions thrown from async specifications

### DIFF
--- a/src/Machine.Specifications.Core.Specs/Machine.Specifications.Core.Specs.csproj
+++ b/src/Machine.Specifications.Core.Specs/Machine.Specifications.Core.Specs.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Machine.Specifications.Core.Specs/Runner/AsyncDelegateRunnerSpecs.cs
+++ b/src/Machine.Specifications.Core.Specs/Runner/AsyncDelegateRunnerSpecs.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using Example.Exceptions;
 using Machine.Specifications.Factories;
 using Machine.Specifications.Runner;
 using Machine.Specifications.Runner.Impl;
@@ -70,6 +71,11 @@ namespace Machine.Specifications.Specs.Runner
 
         It should_have_failures = () =>
             results.ShouldEachConformTo(x => !x.Passed);
+
+        It should_have_exception_details = () =>
+            results.ShouldEachConformTo(r => r.Exception.TypeName == nameof(InvalidOperationException) &&
+                                                   r.Exception.Message == "something went wrong" &&
+                                                   r.Exception.StackTrace.Contains(typeof(AsyncSpecificationsWithExceptions).FullName));
     }
 
     [Subject("Async Delegate Runner")]

--- a/src/Machine.Specifications.Core/Runner/Impl/AsyncSynchronizationContext.cs
+++ b/src/Machine.Specifications.Core/Runner/Impl/AsyncSynchronizationContext.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -12,7 +13,7 @@ namespace Machine.Specifications.Runner.Impl
 
         private int callCount;
 
-        private Exception exception;
+        private ExceptionDispatchInfo exceptionDispatchInfo;
 
         public AsyncSynchronizationContext(SynchronizationContext inner)
         {
@@ -27,7 +28,7 @@ namespace Machine.Specifications.Runner.Impl
             }
             catch (Exception ex)
             {
-                exception = ex;
+                exceptionDispatchInfo = ExceptionDispatchInfo.Capture(ex);
             }
             finally
             {
@@ -88,15 +89,15 @@ namespace Machine.Specifications.Runner.Impl
             }
             catch (Exception ex)
             {
-                exception = ex;
+                exceptionDispatchInfo = ExceptionDispatchInfo.Capture(ex);;
             }
         }
 
-        public async Task<Exception> WaitAsync()
+        public async Task<ExceptionDispatchInfo> WaitAsync()
         {
             await events.WaitAsync();
 
-            return exception;
+            return exceptionDispatchInfo;
         }
     }
 }

--- a/src/Machine.Specifications.Core/Runner/Impl/DelegateRunner.cs
+++ b/src/Machine.Specifications.Core/Runner/Impl/DelegateRunner.cs
@@ -36,12 +36,9 @@ namespace Machine.Specifications.Runner.Impl
             {
                 target.DynamicInvoke(args);
 
-                var exception = context.WaitAsync().Result;
+                var exceptionDispatchInfo = context.WaitAsync().Result;
 
-                if (exception != null)
-                {
-                    throw exception;
-                }
+                exceptionDispatchInfo?.Throw();
             }
             finally
             {

--- a/src/Machine.Specifications.Fixtures/RandomFixture.cs
+++ b/src/Machine.Specifications.Fixtures/RandomFixture.cs
@@ -1139,6 +1139,10 @@ namespace Machine.Specifications
         Cleanup after = async () =>
             cleanup_value = await Test();
     }
+}
+
+namespace Example.Exceptions
+{
 
     public class AsyncSpecificationsWithExceptions
     {

--- a/src/Machine.Specifications.Runner.Utility.Specs/Machine.Specifications.Runner.Utility.Specs.csproj
+++ b/src/Machine.Specifications.Runner.Utility.Specs/Machine.Specifications.Runner.Utility.Specs.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Machine.Specifications.Should.Specs/Machine.Specifications.Should.Specs.csproj
+++ b/src/Machine.Specifications.Should.Specs/Machine.Specifications.Should.Specs.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
Fix for #521 , use `ExceptionDispatchInfo` to capture the thrown exception and preserve the stack trace